### PR TITLE
Add PDF resource and tests

### DIFF
--- a/repository/repository/controllers.py
+++ b/repository/repository/controllers.py
@@ -4,17 +4,18 @@ Request controllers for the repository service.
 These are used to handle requests originating from :mod:`.routes.api`.
 """
 
-from typing import Tuple, Any, Dict
+from typing import Tuple, Any, Dict, Union
 from http import HTTPStatus
 
 from werkzeug.datastructures import MultiDict
 from werkzeug.exceptions import NotFound
 
 from .services.record import CanonicalStore, DoesNotExist
+from arxiv.canonical.domain import File
 
 
 Response = Tuple[Dict[str, Any], HTTPStatus, Dict[str, str]]
-
+FileResponse = Tuple[Union[Dict[str, Any], File], HTTPStatus, Dict[str, str]]
 
 def service_status(params: MultiDict) -> Response:
     """
@@ -50,7 +51,7 @@ def get_eprint_events(identifier: str, version: int) -> Response:
     return eprint.history, HTTPStatus.OK, {}
 
 
-def get_eprint_pdf(identifier: str, version: int) -> Response:
+def get_eprint_pdf(identifier: str, version: int) -> FileResponse:
     """
     Retrieve pdf for a specific e-print version.
 

--- a/repository/repository/controllers.py
+++ b/repository/repository/controllers.py
@@ -48,4 +48,28 @@ def get_eprint_events(identifier: str, version: int) -> Response:
     except DoesNotExist as e:
         raise NotFound(f'No such e-print: {identifier}v{version}') from e
     return eprint.history, HTTPStatus.OK, {}
-    
+
+
+def get_eprint_pdf(identifier: str, version: int) -> Response:
+    """
+    Retrieve pdf for a specific e-print version.
+
+    Parameters
+    ----------
+    identifier : str
+        A valid arXiv identifier.
+    version : int
+        Numeric version of the e-print.
+
+    Raises
+    ------
+    :class:`.NotFound`
+        Raised when the requested identifier + version does not exist.
+
+    """
+    estore = CanonicalStore.current_session()
+    try:
+        eprint = estore.load_eprint(identifier, version)
+    except DoesNotExist as e:
+        raise NotFound(f'No such e-print: {identifier}v{version}') from e
+    return eprint.pdf, HTTPStatus.OK, {}

--- a/repository/repository/routes/api.py
+++ b/repository/repository/routes/api.py
@@ -1,6 +1,7 @@
 """Defines the HTTP routes and methods supported by the repository API."""
 
-from flask import Blueprint, Response, request
+from flask import Blueprint, Response, request, send_file
+
 from flask.json import jsonify
 
 from .. import controllers
@@ -29,3 +30,14 @@ def get_eprint_events(identifier: str, version: int) -> Response:
     """Get events for a specific version of an e-print."""
     data, code, headers = controllers.get_eprint_events(identifier, version)
     return jsonify(data), code, headers
+
+
+@blueprint.route('/e-print/<arxiv:identifier>v<int:version>/pdf',
+                 methods=['GET'])
+def get_eprint_pdf(identifier: str, version: int) -> Response:
+    """Get PDF for a specific version of an e-print."""
+    pdf, code, headers = controllers.get_eprint_pdf(identifier, version)
+    response = send_file(pdf.content, as_attachment=True,
+                         attachment_filename=pdf.filename,
+                         last_modified=pdf.modified)
+    return response, code, headers

--- a/repository/repository/routes/api.py
+++ b/repository/repository/routes/api.py
@@ -36,8 +36,10 @@ def get_eprint_events(identifier: str, version: int) -> Response:
                  methods=['GET'])
 def get_eprint_pdf(identifier: str, version: int) -> Response:
     """Get PDF for a specific version of an e-print."""
-    pdf, code, headers = controllers.get_eprint_pdf(identifier, version)
-    response = send_file(pdf.content, as_attachment=True,
-                         attachment_filename=pdf.filename,
-                         last_modified=pdf.modified)
-    return response, code, headers
+    pdf, status_code, headers = controllers.get_eprint_pdf(identifier, version)
+    response: Response = send_file(pdf.content, as_attachment=True,
+                                   attachment_filename=pdf.filename,
+                                   last_modified=pdf.modified)
+    response.status_code = status_code
+    response.headers.extend(headers)
+    return response

--- a/repository/tests/test_app.py
+++ b/repository/tests/test_app.py
@@ -31,3 +31,32 @@ class TestGetEPrintEvents(TestCase):
         
         response = self.client.get('/e-print/1902.00123v4/events')
         self.assertEqual(response.status_code, HTTPStatus.OK)
+
+
+class TestGetEPrintPDF(TestCase):
+    """Requests for e-print PDFs."""
+
+    def setUp(self):
+        """Spin up an app."""
+        self.app = create_api_app()
+        self.client = self.app.test_client()
+
+    @mock.patch(f'repository.controllers.CanonicalStore')
+    def test_request_for_nonexistant_eprint(self, mock_CanonicalStore):
+        """Get PDF for a nonexistant e-print."""
+        mock_CanonicalStore.current_session.return_value = mock.MagicMock(
+            load_eprint=mock.MagicMock(side_effect=DoesNotExist)
+        )
+        response = self.client.get('/e-print/1902.00123v4/pdf')
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
+
+    @mock.patch(f'repository.controllers.CanonicalStore')
+    def test_request_for_existant_eprint(self, mock_CanonicalStore):
+        """A request is received for an existant e-print."""
+        mock_CanonicalStore.current_session.return_value \
+            = CanonicalStore.current_session()
+        response = self.client.get('/e-print/1902.00123v4/pdf')
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual(response.headers['Content-Disposition'],
+                         'attachment; filename=1901.00123.pdf')
+        self.assertEqual(response.data, b'foopdf')


### PR DESCRIPTION
This implements the PDF retrieval resource.

It returns the PDF file as an attachment so the file name can be set in the response headers.

It also sets the Last-Modified header from the file object.

This resolves use-case #13.