### PR TITLE
Third draft for extended arXiv document metadata

### DIFF
--- a/schema-extended/arxiv-extended.json
+++ b/schema-extended/arxiv-extended.json
@@ -266,8 +266,7 @@
           }
         },
         "required": [
-          "full_name",
-          "last_name"
+          "full_name"
         ],
         "$comment": "Removed requirement for first name. Some people do not have a last name--optional too?"
       },

--- a/schema-extended/arxiv-extended.json
+++ b/schema-extended/arxiv-extended.json
@@ -692,27 +692,35 @@
         "required": ["arxiv_id"],
         "additionalProperties": false
       },
-      "primary_classification": {
-        "title": "Primary classification",
-        "description": "Primary classification of this document.",
-        "$ref": "#/definitions/category",
-        "examples": [
-          "cs.AI",
-          "hep-th"
-        ]
-      },
-      "secondary_classifications": {
-        "title": "Secondary classifications",
-        "description": "Optional and unranked secondary classifications of this document; sorted alphabetically when displayed.",
-        "type": "array",
-        "items": { "$ref": "#/definitions/category" },
-        "minItems": 1,
-        "uniqueItems": true,
-        "examples": [
-          ["cs.DL"],
-          ["cs.SI", "physics.soc-ph"]
-        ]
-
+      "classification": {
+        "title": "Classification",
+        "description": "Classification of this document as it relates to arXiv's category taxonomy.",
+        "type": "object",
+        "properties": {
+          "primary": {
+            "title": "Primary classification",
+            "description": "Primary classification of this document.",
+            "$ref": "#/definitions/category",
+            "examples": [
+              "cs.AI",
+              "hep-th"
+            ]
+          },
+          "secondaries": {
+            "title": "Secondary classifications",
+            "description": "Optional and unranked secondary classifications of this document; sorted alphabetically when displayed.",
+            "type": "array",
+            "items": { "$ref": "#/definitions/category" },
+            "minItems": 1,
+            "uniqueItems": true,
+            "examples": [
+              ["cs.DL"],
+              ["cs.SI", "physics.soc-ph"]
+            ]
+          }
+        },
+        "required": ["primary"],
+        "additionalProperties": false
       },
       "versions": {
         "title": "List of arXiv document versions",
@@ -725,7 +733,7 @@
     },
     "required": [
       "identifiers",
-      "primary_classification",
+      "classification",
       "versions"
     ]
 }

--- a/schema-extended/arxiv-extended.json
+++ b/schema-extended/arxiv-extended.json
@@ -99,7 +99,6 @@
       "conference_info": {
         "title": "Conference information",
         "type": "object",
-        "$comment": "based on subset of INSPIRE's definition",
         "properties": {
           "conference_titles": {
             "title": "List of conference titles",
@@ -110,6 +109,13 @@
             },
             "minItems": 1,
             "uniqueItems": true
+          },
+          "conference_pid": {
+            "title": "Conference Persistent Identifier",
+            "$comment": "placeholder to support: https://www.crossref.org/working-groups/conferences-projects/",
+            "description": "The persistent identifier for the conference.",
+            "type": "string",
+            "minLength": 1
           }
         },
         "required": [

--- a/schema-extended/arxiv-extended.json
+++ b/schema-extended/arxiv-extended.json
@@ -681,9 +681,18 @@
         "description": "Canonical arXiv e-print identifier, without a version affix.",
         "$ref": "#/definitions/unversioned_identifier"
       },
-      "classifications": {
-        "title": "Classifications",
-        "description": "Primary and optional secondary classifications of this document. Primary must be listed first (0-index); secondaries are unranked.",
+      "primary_classification": {
+        "title": "Primary classification",
+        "description": "Primary classification of this document.",
+        "$ref": "#/definitions/category",
+        "examples": [
+          "cs.AI",
+          "hep-th"
+        ]
+      },
+      "secondary_classifications": {
+        "title": "Secondary classifications",
+        "description": "Optional and unranked secondary classifications of this document. Sorted alphabetically in display.",
         "type": "array",
         "items": { "$ref": "#/definitions/category" },
         "minItems": 1,
@@ -691,8 +700,7 @@
         "examples": [
           ["cs.DL"],
           ["cs.SI", "physics.soc-ph"]
-        ],
-        "$comment": "This is an alternative to separate primary and secondary classification fields."
+        ]
       },
       "versions": {
         "title": "List of arXiv document versions",
@@ -705,7 +713,7 @@
     },
     "required": [
       "identifier",
-      "classifications",
+      "primary_classification",
       "versions"
     ]
 }

--- a/schema-extended/arxiv-extended.json
+++ b/schema-extended/arxiv-extended.json
@@ -420,8 +420,23 @@
 
         "type": "object",
         "properties": {
-          "identifier": {
-            "$ref": "#/definitions/versioned_identifier"
+          "identifiers": {
+            "title": "arXiv-issued identifiers for this version.",
+            "type": "object",
+            "properties": {
+                "arxiv_idv": {
+                  "title": "arXiv identifier",
+                  "description": "The arXiv identifier for this version, with a version affix.",
+                  "$ref": "#/definitions/versioned_identifier"
+                },
+                "arxiv_doi": {
+                  "title": "arXiv DOI",
+                  "description": "The arXiv-issued DOI for this version.",
+                  "$ref": "#/definitions/doi"
+                }
+            },
+            "required": ["arxiv_idv"],
+            "additionalProperties": false
           },
           "document_types": {
             "title": "List of document types",
@@ -569,11 +584,6 @@
             "minItems": 1,
             "uniqueItems": true
           },
-          "arxiv_doi": {
-            "title": "arXiv DOI",
-            "description": "The arXiv-issued DOI.",
-            "$ref": "#/definitions/doi"
-          },
           "report_numbers": {
             "title": "List of report numbers",
             "type": "array",
@@ -651,7 +661,7 @@
           }
         },
         "required": [
-          "identifier",
+          "identifiers",
           "submitted_date",
           "announced_date",
           "license",
@@ -676,10 +686,23 @@
         "minLength": 1,
         "$comment": "This is an unconventional/unsanctioned way to use the $schema property as a schema declaration in an instance, but there are some real-world precedents for this (e.g. INSPIRE, Azure templates)"
       },
-      "identifier": {
-        "title": "arXiv identifier",
-        "description": "Canonical arXiv e-print identifier, without a version affix.",
-        "$ref": "#/definitions/unversioned_identifier"
+      "identifiers": {
+        "title": "arXiv-issued identifiers for this document.",
+        "type": "object",
+        "properties": {
+            "arxiv_id": {
+              "title": "arXiv identifier",
+              "description": "The canonical arXiv identifier for this document, without a version affix.",
+              "$ref": "#/definitions/unversioned_identifier"
+            },
+            "arxiv_doi": {
+              "title": "arXiv DOI",
+              "description": "The arXiv-issued DOI for this document.",
+              "$ref": "#/definitions/doi"
+            }
+        },
+        "required": ["arxiv_id"],
+        "additionalProperties": false
       },
       "primary_classification": {
         "title": "Primary classification",
@@ -692,7 +715,7 @@
       },
       "secondary_classifications": {
         "title": "Secondary classifications",
-        "description": "Optional and unranked secondary classifications of this document. Sorted alphabetically in display.",
+        "description": "Optional and unranked secondary classifications of this document; sorted alphabetically when displayed.",
         "type": "array",
         "items": { "$ref": "#/definitions/category" },
         "minItems": 1,
@@ -701,6 +724,7 @@
           ["cs.DL"],
           ["cs.SI", "physics.soc-ph"]
         ]
+
       },
       "versions": {
         "title": "List of arXiv document versions",
@@ -712,7 +736,7 @@
       }
     },
     "required": [
-      "identifier",
+      "identifiers",
       "primary_classification",
       "versions"
     ]

--- a/schema-extended/arxiv-extended.json
+++ b/schema-extended/arxiv-extended.json
@@ -400,9 +400,9 @@
         "pattern": "^(([0-9]{4}\\.[0-9]{4,5})|([a-z\\-]+\\/[0-9]{2}[01][0-9]{4}))v[0-9]+$"
       },
       "version": {
-
         "type": "object",
         "properties": {
+
           "identifiers": {
             "title": "arXiv-issued identifiers for this version.",
             "type": "object",

--- a/schema-extended/arxiv-extended.json
+++ b/schema-extended/arxiv-extended.json
@@ -159,6 +159,7 @@
             "minLength": 1
           }
         },
+        "required": ["funding_statement"],
         "additionalProperties": false
       },
       "language": {
@@ -233,16 +234,9 @@
           },
           "orcid": {
             "title": "ORCID iD",
-            "allOf": [
-              {
-                "type": "string",
-                "pattern": "^\\d{4}-\\d{4}-\\d{4}-\\d{3}[0-9X]$"
-              },
-              {
-                "type": "string",
-                "$comment": "TODO: consider adding 'orcid' format here; would need to implement validator using checksum method described in https://support.orcid.org/hc/en-us/articles/360006897674-Structure-of-the-ORCID-Identifier"
-              }
-            ]
+            "type": "string",
+            "pattern": "^\\d{4}-\\d{4}-\\d{4}-\\d{3}[0-9X]$",
+            "$comment": "TODO: implement custom validator using checksum method described in https://support.orcid.org/hc/en-us/articles/360006897674-Structure-of-the-ORCID-Identifier"
           },
           "author_id": {
             "description": "arXiv author identifier, if available.",

--- a/schema-extended/arxiv-extended.json
+++ b/schema-extended/arxiv-extended.json
@@ -110,16 +110,6 @@
             },
             "minItems": 1,
             "uniqueItems": true
-          },
-          "cnum": {
-            "title": "CNUM identifier of the conference",
-            "description": "The CNUM is based on the starting day of the conference, with an extra number appended to distinguish conferences starting on the first day.",
-            "type": "string",
-            "pattern": "^C\\d\\d-\\d\\d-\\d\\d(\\.\\d+)?$",
-            "examples": [
-              "C87-12-25",
-              "C87-12-25.2"
-            ]
           }
         },
         "required": [

--- a/schema-extended/arxiv-extended.json
+++ b/schema-extended/arxiv-extended.json
@@ -577,36 +577,35 @@
             "minItems": 1,
             "uniqueItems": true
           },
-          "msc_classes": {
-            "title": "List of MSC classes",
-            "description": "Classifications from American Mathematical Society Mathematical Subject Classification (MSC).",
-            "type": "string",
-            "minLength": 1,
-            "examples": [
-              "Primary 14N35, Secondary 14H10, 14H20, 14J26",
-              "Primary 46F30. Secondary: 44A10, 46S10, 46F10, 12J15, 12J25, 16W60",
-              "46B20, 47H10, 54B20, 54F15, 68U05"
-            ],
-            "$comment": "TODO: consider array of an enumerated definition instead. Legacy input is inconsistent."
-
-          },
           "keywords": {
             "title": "List of keywords",
-            "description": "Keywords may include ACM and MSC subject classes.",
+            "description": "A list of individual keywords that may belong to a vocabulary.",
             "type": "array",
-            "$comment": "WIP, consolidate subject classes"
-          },
-          "acm_classes": {
-            "title": "List of ACM classes",
-            "description": "Classifications from ACM Computing Classification System.",
-            "type": "string",
-            "minLength": 1,
-            "examples": [
-              "C.2.0; C.2.2; C.2.3; C.2.6",
-              "I.3.5",
-              "G.1.6; F.1.1; I.2.6; G.1.3"
-            ],
-            "$comment": "TODO: consider array of an enumerated definition instead. Legacy input is inconsistent."
+            "items": {
+              "type": "object",
+              "properties": {
+                "vocabulary": {
+                  "title": "Keyword vocabulary",
+                  "description": "The keyword vocabulary this keyword belongs to.",
+                  "type": "string",
+                  "enum": ["ACM", "INIS", "JACOW", "MSC", "PACS", "PDG", "UAT"]
+                },
+                "value": {
+                  "title": "Keyword",
+                  "description": "A keyword that is either part of a vocabulary or free-form.",
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "examples": [
+                [{"vocabulary": "ACM", "value": "C.2.0;"}, {"vocabulary": "ACM", "value": "C.2.2"}],
+                [{"vocabulary": "MSC", "value": "46B20"}]
+              ],
+              "required": ["value"],
+              "additionalProperties": false
+            },
+            "minItems": 1,
+            "uniqueItems": true
           },
           "related_links": {
             "title": "List of related links",

--- a/schema-extended/arxiv-extended.yaml
+++ b/schema-extended/arxiv-extended.yaml
@@ -78,7 +78,6 @@ definitions:
   conference_info:
     title: Conference information
     type: object
-    $comment: based on subset of INSPIRE's definition
     properties:
       conference_titles:
         title: List of conference titles
@@ -88,6 +87,12 @@ definitions:
           minLength: 1
         minItems: 1
         uniqueItems: true
+      conference_pid:
+        title: Conference Persistent Identifier
+        $comment: "placeholder to support: https://www.crossref.org/working-groups/conferences-projects/"
+        description: The persistent identifier for the conference.
+        type: string
+        minLength: 1
     required:
     - conference_titles
   document_type:
@@ -618,26 +623,35 @@ properties:
     required:
     - arxiv_id
     additionalProperties: false
-  primary_classification:
-    title: Primary classification
-    description: Primary classification of this document.
-    $ref: '#/definitions/category'
-    examples:
-    - cs.AI
-    - hep-th
-  secondary_classifications:
-    title: Secondary classifications
-    description: Optional and unranked secondary classifications of this document;
-      sorted alphabetically when displayed.
-    type: array
-    items:
-      $ref: '#/definitions/category'
-    minItems: 1
-    uniqueItems: true
-    examples:
-    - - cs.DL
-    - - cs.SI
-      - physics.soc-ph
+  classification:
+    title: Classification
+    description: Classification of this document as it relates to arXiv's category
+      taxonomy.
+    type: object
+    properties:
+      primary:
+        title: Primary classification
+        description: Primary classification of this document.
+        $ref: '#/definitions/category'
+        examples:
+        - cs.AI
+        - hep-th
+      secondaries:
+        title: Secondary classifications
+        description: Optional and unranked secondary classifications of this document;
+          sorted alphabetically when displayed.
+        type: array
+        items:
+          $ref: '#/definitions/category'
+        minItems: 1
+        uniqueItems: true
+        examples:
+        - - cs.DL
+        - - cs.SI
+          - physics.soc-ph
+    required:
+    - primary
+    additionalProperties: false
   versions:
     title: List of arXiv document versions
     type: array
@@ -646,5 +660,5 @@ properties:
     minItems: 1
 required:
 - identifiers
-- primary_classification
+- classification
 - versions

--- a/schema-extended/arxiv-extended.yaml
+++ b/schema-extended/arxiv-extended.yaml
@@ -88,16 +88,6 @@ definitions:
           minLength: 1
         minItems: 1
         uniqueItems: true
-      cnum:
-        title: CNUM identifier of the conference
-        description: "The CNUM is based on the starting day of the conference, with\
-          \ an extra number appended to distinguish conferences starting on the first\
-          \ day."
-        type: string
-        pattern: ^C\d\d-\d\d-\d\d(\.\d+)?$
-        examples:
-        - C87-12-25
-        - C87-12-25.2
     required:
     - conference_titles
   document_type:
@@ -149,6 +139,8 @@ definitions:
         title: Grant number
         type: string
         minLength: 1
+    required:
+    - funding_statement
     additionalProperties: false
   language:
     description: The 2-letter ISO 639-1 language classification.
@@ -216,12 +208,10 @@ definitions:
         minItems: 1
       orcid:
         title: ORCID iD
-        allOf:
-        - type: string
-          pattern: "^\\d{4}-\\d{4}-\\d{4}-\\d{3}[0-9X]$"
-        - type: string
-          $comment: "TODO: consider adding 'orcid' format here; would need to implement\
-            \ validator using checksum method described in https://support.orcid.org/hc/en-us/articles/360006897674-Structure-of-the-ORCID-Identifier"
+        type: string
+        pattern: "^\\d{4}-\\d{4}-\\d{4}-\\d{3}[0-9X]$"
+        $comment: "TODO: implement custom validator using checksum method described\
+          \ in https://support.orcid.org/hc/en-us/articles/360006897674-Structure-of-the-ORCID-Identifier"
       author_id:
         description: "arXiv author identifier, if available."
         type: string
@@ -232,7 +222,6 @@ definitions:
         type: boolean
     required:
     - full_name
-    - last_name
     $comment: Removed requirement for first name. Some people do not have a last name--optional
       too?
   arxiv_status:
@@ -389,8 +378,21 @@ definitions:
   version:
     type: object
     properties:
-      identifier:
-        $ref: '#/definitions/versioned_identifier'
+      identifiers:
+        title: arXiv-issued identifiers for this version.
+        type: object
+        properties:
+          arxiv_idv:
+            title: arXiv identifier
+            description: "The arXiv identifier for this version, with a version affix."
+            $ref: '#/definitions/versioned_identifier'
+          arxiv_doi:
+            title: arXiv DOI
+            description: The arXiv-issued DOI for this version.
+            $ref: '#/definitions/doi'
+        required:
+        - arxiv_idv
+        additionalProperties: false
       document_types:
         title: List of document types
         type: array
@@ -507,10 +509,6 @@ definitions:
           $ref: '#/definitions/doi'
         minItems: 1
         uniqueItems: true
-      arxiv_doi:
-        title: arXiv DOI
-        description: The arXiv-issued DOI.
-        $ref: '#/definitions/doi'
       report_numbers:
         title: List of report numbers
         type: array
@@ -519,34 +517,42 @@ definitions:
           minLength: 1
         minItems: 1
         uniqueItems: true
-      msc_classes:
-        title: List of MSC classes
-        description: Classifications from American Mathematical Society Mathematical
-          Subject Classification (MSC).
-        type: string
-        minLength: 1
-        examples:
-        - "Primary 14N35, Secondary 14H10, 14H20, 14J26"
-        - "Primary 46F30. Secondary: 44A10, 46S10, 46F10, 12J15, 12J25, 16W60"
-        - "46B20, 47H10, 54B20, 54F15, 68U05"
-        $comment: "TODO: consider array of an enumerated definition instead. Legacy\
-          \ input is inconsistent."
       keywords:
         title: List of keywords
-        description: Keywords may include ACM and MSC subject classes.
+        description: A list of individual keywords that may belong to a vocabulary.
         type: array
-        $comment: "WIP, consolidate subject classes"
-      acm_classes:
-        title: List of ACM classes
-        description: Classifications from ACM Computing Classification System.
-        type: string
-        minLength: 1
-        examples:
-        - C.2.0; C.2.2; C.2.3; C.2.6
-        - I.3.5
-        - G.1.6; F.1.1; I.2.6; G.1.3
-        $comment: "TODO: consider array of an enumerated definition instead. Legacy\
-          \ input is inconsistent."
+        items:
+          type: object
+          properties:
+            vocabulary:
+              title: Keyword vocabulary
+              description: The keyword vocabulary this keyword belongs to.
+              type: string
+              enum:
+              - ACM
+              - INIS
+              - JACOW
+              - MSC
+              - PACS
+              - PDG
+              - UAT
+            value:
+              title: Keyword
+              description: A keyword that is either part of a vocabulary or free-form.
+              type: string
+              minLength: 1
+          examples:
+          - - vocabulary: ACM
+              value: C.2.0;
+            - vocabulary: ACM
+              value: C.2.2
+          - - vocabulary: MSC
+              value: 46B20
+          required:
+          - value
+          additionalProperties: false
+        minItems: 1
+        uniqueItems: true
       related_links:
         title: List of related links
         type: array
@@ -574,7 +580,7 @@ definitions:
           $ref: '#/definitions/reference_string'
         uniqueItems: true
     required:
-    - identifier
+    - identifiers
     - submitted_date
     - announced_date
     - license
@@ -596,14 +602,33 @@ properties:
     $comment: "This is an unconventional/unsanctioned way to use the $schema property\
       \ as a schema declaration in an instance, but there are some real-world precedents\
       \ for this (e.g. INSPIRE, Azure templates)"
-  identifier:
-    title: arXiv identifier
-    description: "Canonical arXiv e-print identifier, without a version affix."
-    $ref: '#/definitions/unversioned_identifier'
-  classifications:
-    title: Classifications
-    description: Primary and optional secondary classifications of this document.
-      Primary must be listed first (0-index); secondaries are unranked.
+  identifiers:
+    title: arXiv-issued identifiers for this document.
+    type: object
+    properties:
+      arxiv_id:
+        title: arXiv identifier
+        description: "The canonical arXiv identifier for this document, without a\
+          \ version affix."
+        $ref: '#/definitions/unversioned_identifier'
+      arxiv_doi:
+        title: arXiv DOI
+        description: The arXiv-issued DOI for this document.
+        $ref: '#/definitions/doi'
+    required:
+    - arxiv_id
+    additionalProperties: false
+  primary_classification:
+    title: Primary classification
+    description: Primary classification of this document.
+    $ref: '#/definitions/category'
+    examples:
+    - cs.AI
+    - hep-th
+  secondary_classifications:
+    title: Secondary classifications
+    description: Optional and unranked secondary classifications of this document;
+      sorted alphabetically when displayed.
     type: array
     items:
       $ref: '#/definitions/category'
@@ -613,8 +638,6 @@ properties:
     - - cs.DL
     - - cs.SI
       - physics.soc-ph
-    $comment: This is an alternative to separate primary and secondary classification
-      fields.
   versions:
     title: List of arXiv document versions
     type: array
@@ -622,6 +645,6 @@ properties:
       $ref: '#/definitions/version'
     minItems: 1
 required:
-- identifier
-- classifications
+- identifiers
+- primary_classification
 - versions

--- a/schema-extended/docs/arxiv-extended.html
+++ b/schema-extended/docs/arxiv-extended.html
@@ -5,16 +5,22 @@
       <title>Documentation arxiv-extended.json</title>
       <link rel="stylesheet" href="docHtml.css" type="text/css"><script>var sourceBoxes= new Array('source_#/Main Schema', 
 				'source_#/properties/$schema', 
-				'source_#/properties/identifier', 
-				'source_#/properties/classifications', 
-				'source_#/properties/classifications/items', 
+				'source_#/properties/identifiers', 
+				'source_#/properties/identifiers/properties/arxiv_id', 
+				'source_#/properties/identifiers/properties/arxiv_doi', 
+				'source_#/properties/primary_classification', 
+				'source_#/properties/secondary_classifications', 
+				'source_#/properties/secondary_classifications/items', 
 				'source_#/properties/versions', 
 				'source_#/properties/versions/items', 
 				'source_#/definitions/unversioned_identifier', 
+				'source_#/definitions/doi', 
 				'source_#/definitions/category', 
 				'source_#/definitions/version', 
+				'source_#/definitions/version/properties/identifiers', 
 				'source_#/definitions/versioned_identifier', 
-				'source_#/definitions/version/properties/identifier', 
+				'source_#/definitions/version/properties/identifiers/properties/arxiv_idv', 
+				'source_#/definitions/version/properties/identifiers/properties/arxiv_doi', 
 				'source_#/definitions/version/properties/document_types', 
 				'source_#/definitions/document_type', 
 				'source_#/definitions/version/properties/document_types/items', 
@@ -30,8 +36,6 @@
 				'source_#/definitions/affiliation/properties/ror_id', 
 				'source_#/definitions/person/properties/affiliations/items', 
 				'source_#/definitions/person/properties/orcid', 
-				'source_#/definitions/person/properties/orcid/allOf/0', 
-				'source_#/definitions/person/properties/orcid/allOf/1', 
 				'source_#/definitions/person/properties/author_id', 
 				'source_#/definitions/person/properties/is_submitter', 
 				'source_#/definitions/version/properties/submitter_info/properties/submitter', 
@@ -80,16 +84,15 @@
 				'source_#/definitions/version/properties/comments/properties/legacy_comments', 
 				'source_#/definitions/version/properties/journal_ref', 
 				'source_#/definitions/version/properties/publisher_dois', 
-				'source_#/definitions/doi', 
 				'source_#/definitions/version/properties/publisher_dois/items', 
 				'source_#/definitions/version/properties/submitter_dois', 
 				'source_#/definitions/version/properties/submitter_dois/items', 
-				'source_#/definitions/version/properties/arxiv_doi', 
 				'source_#/definitions/version/properties/report_numbers', 
 				'source_#/definitions/version/properties/report_numbers/items', 
-				'source_#/definitions/version/properties/msc_classes', 
 				'source_#/definitions/version/properties/keywords', 
-				'source_#/definitions/version/properties/acm_classes', 
+				'source_#/definitions/version/properties/keywords/items', 
+				'source_#/definitions/version/properties/keywords/items/properties/vocabulary', 
+				'source_#/definitions/version/properties/keywords/items/properties/value', 
 				'source_#/definitions/version/properties/related_links', 
 				'source_#/definitions/related_link', 
 				'source_#/definitions/related_link/properties/uri', 
@@ -112,19 +115,25 @@
 				'source_#/definitions/conference_info', 
 				'source_#/definitions/conference_info/properties/conference_titles', 
 				'source_#/definitions/conference_info/properties/conference_titles/items', 
-				'source_#/definitions/conference_info/properties/cnum', 
 				'source_#/definitions/version/properties/conference_info', 
 				'source_#/definitions/version/properties/references', 
 				'source_#/definitions/reference_string', 
 				'source_#/definitions/version/properties/references/items');
 var annotationsBoxes= new Array('annotations_#/Main Schema', 
 				'annotations_#/properties/$schema', 
-				'annotations_#/properties/identifier', 
-				'annotations_#/properties/classifications', 
+				'annotations_#/properties/identifiers', 
+				'annotations_#/properties/identifiers/properties/arxiv_id', 
+				'annotations_#/properties/identifiers/properties/arxiv_doi', 
+				'annotations_#/properties/primary_classification', 
+				'annotations_#/properties/secondary_classifications', 
 				'annotations_#/properties/versions', 
 				'annotations_#/definitions/unversioned_identifier', 
+				'annotations_#/definitions/doi', 
 				'annotations_#/definitions/category', 
+				'annotations_#/definitions/version/properties/identifiers', 
 				'annotations_#/definitions/versioned_identifier', 
+				'annotations_#/definitions/version/properties/identifiers/properties/arxiv_idv', 
+				'annotations_#/definitions/version/properties/identifiers/properties/arxiv_doi', 
 				'annotations_#/definitions/version/properties/document_types', 
 				'annotations_#/definitions/document_type', 
 				'annotations_#/definitions/version/properties/submitter_info', 
@@ -160,13 +169,11 @@ var annotationsBoxes= new Array('annotations_#/Main Schema',
 				'annotations_#/definitions/version/properties/comments/properties/legacy_comments', 
 				'annotations_#/definitions/version/properties/journal_ref', 
 				'annotations_#/definitions/version/properties/publisher_dois', 
-				'annotations_#/definitions/doi', 
 				'annotations_#/definitions/version/properties/submitter_dois', 
-				'annotations_#/definitions/version/properties/arxiv_doi', 
 				'annotations_#/definitions/version/properties/report_numbers', 
-				'annotations_#/definitions/version/properties/msc_classes', 
 				'annotations_#/definitions/version/properties/keywords', 
-				'annotations_#/definitions/version/properties/acm_classes', 
+				'annotations_#/definitions/version/properties/keywords/items/properties/vocabulary', 
+				'annotations_#/definitions/version/properties/keywords/items/properties/value', 
 				'annotations_#/definitions/version/properties/related_links', 
 				'annotations_#/definitions/related_link', 
 				'annotations_#/definitions/related_link/properties/display_text', 
@@ -181,11 +188,12 @@ var annotationsBoxes= new Array('annotations_#/Main Schema',
 				'annotations_#/definitions/version/properties/source_info', 
 				'annotations_#/definitions/conference_info', 
 				'annotations_#/definitions/conference_info/properties/conference_titles', 
-				'annotations_#/definitions/conference_info/properties/cnum', 
 				'annotations_#/definitions/version/properties/references', 
 				'annotations_#/definitions/reference_string');
 var propertiesBoxes= new Array('properties_#/Main Schema', 
+				'properties_#/properties/identifiers', 
 				'properties_#/definitions/version', 
+				'properties_#/definitions/version/properties/identifiers', 
 				'properties_#/definitions/version/properties/submitter_info', 
 				'properties_#/definitions/person', 
 				'properties_#/definitions/affiliation', 
@@ -195,14 +203,16 @@ var propertiesBoxes= new Array('properties_#/Main Schema',
 				'properties_#/definitions/abstracts/items/0', 
 				'properties_#/definitions/collaboration', 
 				'properties_#/definitions/version/properties/comments', 
+				'properties_#/definitions/version/properties/keywords/items', 
 				'properties_#/definitions/related_link', 
 				'properties_#/definitions/source_info', 
 				'properties_#/definitions/source_info/properties/checksum/items', 
 				'properties_#/definitions/conference_info');
 var constraintsBoxes= new Array('constraints_#/properties/$schema', 
-				'constraints_#/properties/classifications', 
+				'constraints_#/properties/secondary_classifications', 
 				'constraints_#/properties/versions', 
 				'constraints_#/definitions/unversioned_identifier', 
+				'constraints_#/definitions/doi', 
 				'constraints_#/definitions/category', 
 				'constraints_#/definitions/versioned_identifier', 
 				'constraints_#/definitions/version/properties/document_types', 
@@ -213,7 +223,7 @@ var constraintsBoxes= new Array('constraints_#/properties/$schema',
 				'constraints_#/definitions/person/properties/affiliations', 
 				'constraints_#/definitions/affiliation/properties/name', 
 				'constraints_#/definitions/affiliation/properties/ror_id', 
-				'constraints_#/definitions/person/properties/orcid/allOf/0', 
+				'constraints_#/definitions/person/properties/orcid', 
 				'constraints_#/definitions/person/properties/author_id', 
 				'constraints_#/definitions/version/properties/submitter_info/properties/proxy_name', 
 				'constraints_#/definitions/version/properties/submitted_date', 
@@ -233,13 +243,11 @@ var constraintsBoxes= new Array('constraints_#/properties/$schema',
 				'constraints_#/definitions/version/properties/comments/properties/administrator_comments', 
 				'constraints_#/definitions/version/properties/journal_ref', 
 				'constraints_#/definitions/version/properties/publisher_dois', 
-				'constraints_#/definitions/doi', 
 				'constraints_#/definitions/version/properties/submitter_dois', 
 				'constraints_#/definitions/version/properties/report_numbers', 
 				'constraints_#/definitions/version/properties/report_numbers/items', 
-				'constraints_#/definitions/version/properties/msc_classes', 
 				'constraints_#/definitions/version/properties/keywords', 
-				'constraints_#/definitions/version/properties/acm_classes', 
+				'constraints_#/definitions/version/properties/keywords/items/properties/value', 
 				'constraints_#/definitions/version/properties/related_links', 
 				'constraints_#/definitions/related_link/properties/uri', 
 				'constraints_#/definitions/related_link/properties/display_text', 
@@ -247,13 +255,13 @@ var constraintsBoxes= new Array('constraints_#/properties/$schema',
 				'constraints_#/definitions/source_info/properties/checksum/items/properties/value', 
 				'constraints_#/definitions/conference_info/properties/conference_titles', 
 				'constraints_#/definitions/conference_info/properties/conference_titles/items', 
-				'constraints_#/definitions/conference_info/properties/cnum', 
 				'constraints_#/definitions/version/properties/references', 
 				'constraints_#/definitions/reference_string');
 var enumerationsBoxes= new Array('enumeration_#/definitions/document_type', 
 				'enumeration_#/definitions/active_licenses', 
 				'enumeration_#/definitions/inactive_licenses', 
 				'enumeration_#/definitions/language', 
+				'enumeration_#/definitions/version/properties/keywords/items/properties/vocabulary', 
 				'enumeration_#/definitions/related_link/properties/category', 
 				'enumeration_#/definitions/arxiv_status', 
 				'enumeration_#/definitions/external_publication_status', 
@@ -262,16 +270,22 @@ var enumerationsBoxes= new Array('enumeration_#/definitions/document_type',
 				'enumeration_#/definitions/source_info/properties/checksum/items/properties/algorithm');
 var combinedBoxes= new Array('combined_#/Main Schema', 
 				'combined_#/properties/$schema', 
-				'combined_#/properties/identifier', 
-				'combined_#/properties/classifications', 
-				'combined_#/properties/classifications/items', 
+				'combined_#/properties/identifiers', 
+				'combined_#/properties/identifiers/properties/arxiv_id', 
+				'combined_#/properties/identifiers/properties/arxiv_doi', 
+				'combined_#/properties/primary_classification', 
+				'combined_#/properties/secondary_classifications', 
+				'combined_#/properties/secondary_classifications/items', 
 				'combined_#/properties/versions', 
 				'combined_#/properties/versions/items', 
 				'combined_#/definitions/unversioned_identifier', 
+				'combined_#/definitions/doi', 
 				'combined_#/definitions/category', 
 				'combined_#/definitions/version', 
+				'combined_#/definitions/version/properties/identifiers', 
 				'combined_#/definitions/versioned_identifier', 
-				'combined_#/definitions/version/properties/identifier', 
+				'combined_#/definitions/version/properties/identifiers/properties/arxiv_idv', 
+				'combined_#/definitions/version/properties/identifiers/properties/arxiv_doi', 
 				'combined_#/definitions/version/properties/document_types', 
 				'combined_#/definitions/document_type', 
 				'combined_#/definitions/version/properties/document_types/items', 
@@ -287,8 +301,6 @@ var combinedBoxes= new Array('combined_#/Main Schema',
 				'combined_#/definitions/affiliation/properties/ror_id', 
 				'combined_#/definitions/person/properties/affiliations/items', 
 				'combined_#/definitions/person/properties/orcid', 
-				'combined_#/definitions/person/properties/orcid/allOf/0', 
-				'combined_#/definitions/person/properties/orcid/allOf/1', 
 				'combined_#/definitions/person/properties/author_id', 
 				'combined_#/definitions/person/properties/is_submitter', 
 				'combined_#/definitions/version/properties/submitter_info/properties/submitter', 
@@ -337,16 +349,15 @@ var combinedBoxes= new Array('combined_#/Main Schema',
 				'combined_#/definitions/version/properties/comments/properties/legacy_comments', 
 				'combined_#/definitions/version/properties/journal_ref', 
 				'combined_#/definitions/version/properties/publisher_dois', 
-				'combined_#/definitions/doi', 
 				'combined_#/definitions/version/properties/publisher_dois/items', 
 				'combined_#/definitions/version/properties/submitter_dois', 
 				'combined_#/definitions/version/properties/submitter_dois/items', 
-				'combined_#/definitions/version/properties/arxiv_doi', 
 				'combined_#/definitions/version/properties/report_numbers', 
 				'combined_#/definitions/version/properties/report_numbers/items', 
-				'combined_#/definitions/version/properties/msc_classes', 
 				'combined_#/definitions/version/properties/keywords', 
-				'combined_#/definitions/version/properties/acm_classes', 
+				'combined_#/definitions/version/properties/keywords/items', 
+				'combined_#/definitions/version/properties/keywords/items/properties/vocabulary', 
+				'combined_#/definitions/version/properties/keywords/items/properties/value', 
 				'combined_#/definitions/version/properties/related_links', 
 				'combined_#/definitions/related_link', 
 				'combined_#/definitions/related_link/properties/uri', 
@@ -369,22 +380,27 @@ var combinedBoxes= new Array('combined_#/Main Schema',
 				'combined_#/definitions/conference_info', 
 				'combined_#/definitions/conference_info/properties/conference_titles', 
 				'combined_#/definitions/conference_info/properties/conference_titles/items', 
-				'combined_#/definitions/conference_info/properties/cnum', 
 				'combined_#/definitions/version/properties/conference_info', 
 				'combined_#/definitions/version/properties/references', 
 				'combined_#/definitions/reference_string', 
 				'combined_#/definitions/version/properties/references/items');
 var usedByBoxes= new Array('usedBy_#/properties/$schema', 
-				'usedBy_#/properties/identifier', 
-				'usedBy_#/properties/classifications', 
-				'usedBy_#/properties/classifications/items', 
+				'usedBy_#/properties/identifiers', 
+				'usedBy_#/properties/identifiers/properties/arxiv_id', 
+				'usedBy_#/properties/identifiers/properties/arxiv_doi', 
+				'usedBy_#/properties/primary_classification', 
+				'usedBy_#/properties/secondary_classifications', 
+				'usedBy_#/properties/secondary_classifications/items', 
 				'usedBy_#/properties/versions', 
 				'usedBy_#/properties/versions/items', 
 				'usedBy_#/definitions/unversioned_identifier', 
+				'usedBy_#/definitions/doi', 
 				'usedBy_#/definitions/category', 
 				'usedBy_#/definitions/version', 
+				'usedBy_#/definitions/version/properties/identifiers', 
 				'usedBy_#/definitions/versioned_identifier', 
-				'usedBy_#/definitions/version/properties/identifier', 
+				'usedBy_#/definitions/version/properties/identifiers/properties/arxiv_idv', 
+				'usedBy_#/definitions/version/properties/identifiers/properties/arxiv_doi', 
 				'usedBy_#/definitions/version/properties/document_types', 
 				'usedBy_#/definitions/document_type', 
 				'usedBy_#/definitions/version/properties/document_types/items', 
@@ -400,8 +416,6 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
 				'usedBy_#/definitions/affiliation/properties/ror_id', 
 				'usedBy_#/definitions/person/properties/affiliations/items', 
 				'usedBy_#/definitions/person/properties/orcid', 
-				'usedBy_#/definitions/person/properties/orcid/allOf/0', 
-				'usedBy_#/definitions/person/properties/orcid/allOf/1', 
 				'usedBy_#/definitions/person/properties/author_id', 
 				'usedBy_#/definitions/person/properties/is_submitter', 
 				'usedBy_#/definitions/version/properties/submitter_info/properties/submitter', 
@@ -450,16 +464,15 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
 				'usedBy_#/definitions/version/properties/comments/properties/legacy_comments', 
 				'usedBy_#/definitions/version/properties/journal_ref', 
 				'usedBy_#/definitions/version/properties/publisher_dois', 
-				'usedBy_#/definitions/doi', 
 				'usedBy_#/definitions/version/properties/publisher_dois/items', 
 				'usedBy_#/definitions/version/properties/submitter_dois', 
 				'usedBy_#/definitions/version/properties/submitter_dois/items', 
-				'usedBy_#/definitions/version/properties/arxiv_doi', 
 				'usedBy_#/definitions/version/properties/report_numbers', 
 				'usedBy_#/definitions/version/properties/report_numbers/items', 
-				'usedBy_#/definitions/version/properties/msc_classes', 
 				'usedBy_#/definitions/version/properties/keywords', 
-				'usedBy_#/definitions/version/properties/acm_classes', 
+				'usedBy_#/definitions/version/properties/keywords/items', 
+				'usedBy_#/definitions/version/properties/keywords/items/properties/vocabulary', 
+				'usedBy_#/definitions/version/properties/keywords/items/properties/value', 
 				'usedBy_#/definitions/version/properties/related_links', 
 				'usedBy_#/definitions/related_link', 
 				'usedBy_#/definitions/related_link/properties/uri', 
@@ -482,7 +495,6 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
 				'usedBy_#/definitions/conference_info', 
 				'usedBy_#/definitions/conference_info/properties/conference_titles', 
 				'usedBy_#/definitions/conference_info/properties/conference_titles/items', 
-				'usedBy_#/definitions/conference_info/properties/cnum', 
 				'usedBy_#/definitions/version/properties/conference_info', 
 				'usedBy_#/definitions/version/properties/references', 
 				'usedBy_#/definitions/reference_string', 
@@ -824,8 +836,9 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                               <td class="componentGroup">
                                  <div id="Main_Properties" class="componentGroup" style="display:block">
                                     <div><b><b><a href="#/properties/$schema" target="mainFrame">$schema</a></b></b></div>
-                                    <div><b><b><a href="#/properties/identifier" target="mainFrame">identifier</a></b></b></div>
-                                    <div><b><b><a href="#/properties/classifications" target="mainFrame">classifications</a></b></b></div>
+                                    <div><b><b><a href="#/properties/identifiers" target="mainFrame">identifiers</a></b></b></div>
+                                    <div><b><b><a href="#/properties/primary_classification" target="mainFrame">primary_classification</a></b></b></div>
+                                    <div><b><b><a href="#/properties/secondary_classifications" target="mainFrame">secondary_classifications</a></b></b></div>
                                     <div><b><b><a href="#/properties/versions" target="mainFrame">versions</a></b></b></div>
                                  </div>
                               </td>
@@ -867,6 +880,7 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                               <td class="componentGroup">
                                  <div id="Main_Definitions" class="componentGroup" style="display:block">
                                     <div><b><b><a href="#/definitions/unversioned_identifier" target="mainFrame">unversioned_identifier</a></b></b></div>
+                                    <div><b><b><a href="#/definitions/doi" target="mainFrame">doi</a></b></b></div>
                                     <div><b><b><a href="#/definitions/category" target="mainFrame">category</a></b></b></div>
                                     <div><b><b><a href="#/definitions/version" target="mainFrame">version</a></b></b></div>
                                     <div><b><b><a href="#/definitions/versioned_identifier" target="mainFrame">versioned_identifier</a></b></b></div>
@@ -880,7 +894,6 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                                     <div><b><b><a href="#/definitions/abstracts" target="mainFrame">abstracts</a></b></b></div>
                                     <div><b><b><a href="#/definitions/collaboration" target="mainFrame">collaboration</a></b></b></div>
                                     <div><b><b><a href="#/definitions/comment" target="mainFrame">comment</a></b></b></div>
-                                    <div><b><b><a href="#/definitions/doi" target="mainFrame">doi</a></b></b></div>
                                     <div><b><b><a href="#/definitions/related_link" target="mainFrame">related_link</a></b></b></div>
                                     <div><b><b><a href="#/definitions/arxiv_status" target="mainFrame">arxiv_status</a></b></b></div>
                                     <div><b><b><a href="#/definitions/external_publication_status" target="mainFrame">external_publication_status</a></b></b></div>
@@ -967,8 +980,8 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                                                       </td>
                                                 </tr>
                                                 <tr>
-                                                   <td class="firstColumn" style="white-space: nowrap;"><a href="#/properties/$schema"><span class="Name">$schema<br></span></a><a href="#/properties/identifier"><span class="Name">identifier<br></span></a><a href="#/properties/classifications"><span class="Name">classifications<br></span></a><a href="#/properties/versions"><span class="Name">versions<br></span></a></td>
-                                                   <td><b>optional<br>required<br>required<br>required<br></b></td>
+                                                   <td class="firstColumn" style="white-space: nowrap;"><a href="#/properties/$schema"><span class="Name">$schema<br></span></a><a href="#/properties/identifiers"><span class="Name">identifiers<br></span></a><a href="#/properties/primary_classification"><span class="Name">primary_classification<br></span></a><a href="#/properties/secondary_classifications"><span class="Name">secondary_classifications<br></span></a><a href="#/properties/versions"><span class="Name">versions<br></span></a></td>
+                                                   <td><b>optional<br>required<br>required<br>optional<br>required<br></b></td>
                                                 </tr>
                                              </table>
                                           </div>
@@ -997,8 +1010,8 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
 <span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"Extended metadata record for an arXiv document."</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"$schema"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"http://json-schema.org/draft-07/schema#"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"required"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">[</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(153,51,0)">"identifier"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(153,51,0)">"classifications"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(153,51,0)">"identifiers"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(153,51,0)">"primary_classification"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">    </span><span style="color: rgb(153,51,0)">"versions"</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">  </span><span style="color: rgb(40,40,40)">]</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"properties"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
@@ -1009,17 +1022,28 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
 <span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"Schema URI this document adheres to."</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"$comment"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"This is an unconventional/unsanctioned way to use the $schema property as a schema declaration in an instance, but there are some real-world precedents for this (e.g. INSPIRE, Azure templates)"</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">    </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(0,0,150)">"identifier"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"$ref"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"#/definitions/unversioned_identifier"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"arXiv identifier"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"Canonical arXiv e-print identifier, without a version affix."</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(0,0,150)">"identifiers"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"object"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"additionalProperties"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,90)">false</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"arXiv-issued identifiers for this document."</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"required"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">[</span><span style="color: rgb(153,51,0)">"arxiv_id"</span><span style="color: rgb(40,40,40)">]</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"properties"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">    </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(0,0,150)">"classifications"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(0,0,150)">"primary_classification"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"$ref"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"#/definitions/category"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"Primary classification"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"Primary classification of this document."</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"examples"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">[</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(153,51,0)">"cs.AI"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(153,51,0)">"hep-th"</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(40,40,40)">]</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(0,0,150)">"secondary_classifications"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"array"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"uniqueItems"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,90)">true</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"minItems"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,113,227)">1</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"Classifications"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"Primary and optional secondary classifications of this document. Primary must be listed first (0-index); secondaries are unranked."</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"Secondary classifications"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"Optional and unranked secondary classifications of this document; sorted alphabetically when displayed."</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"examples"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">[</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">        </span><span style="color: rgb(40,40,40)">[</span><span style="color: rgb(153,51,0)">"cs.DL"</span><span style="color: rgb(40,40,40)">]</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">        </span><span style="color: rgb(40,40,40)">[</span><span style="color: rgb(0,0,0)"></span>
@@ -1027,7 +1051,6 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
 <span style="color: rgb(0,0,0)">          </span><span style="color: rgb(153,51,0)">"physics.soc-ph"</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">        </span><span style="color: rgb(40,40,40)">]</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">      </span><span style="color: rgb(40,40,40)">]</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"$comment"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"This is an alternative to separate primary and secondary classification fields."</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"items"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">    </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">    </span><span style="color: rgb(0,0,150)">"versions"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
@@ -1166,7 +1189,7 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                            <td class="rt_lineBottom"></td>
                            <td class="rt_cornerBottomRight"></td>
                         </tr>
-                     </table><br><a name="/properties/identifier"></a><div class="componentTitle">Definition <a href="#/properties/identifier"><span class="Name">identifier</span></a><span class="qname"></span></div>
+                     </table><br><a name="/properties/identifiers"></a><div class="componentTitle">Property <a href="#/properties/identifiers"><span class="Name">identifiers</span></a><span class="qname"></span></div>
                      <table class="rt">
                         <tr>
                            <td class="rt_cornerTopLeft"></td>
@@ -1182,15 +1205,144 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                                     <tr>
                                        <td class="firstColumn">
                                           <div class="floatLeft"><b>Annotations</b></div>
-                                          <div class="floatRight"><input id="button_annotations_#/properties/identifier" type="image" src="img/btM.gif" value="-" onclick="switchState('annotations_#/properties/identifier');" class="control"></div>
+                                          <div class="floatRight"><input id="button_annotations_#/properties/identifiers" type="image" src="img/btM.gif" value="-" onclick="switchState('annotations_#/properties/identifiers');" class="control"></div>
                                        </td>
                                        <td>
-                                          <div id="annotations_#/properties/identifier" style="display:block">
+                                          <div id="annotations_#/properties/identifiers" style="display:block">
                                              <div class="annotation">
                                                 <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
                                                    <tr>
                                                       <td width="100%">
-                                                         <pre><span class="DetailName">Title  </span><span class="tT">arXiv identifier</span></pre><br><pre><span class="DetailName">Description  </span><span class="tT">Canonical arXiv e-print identifier, without a version affix.</span></pre>
+                                                         <pre><span class="DetailName">Title  </span><span class="tT">arXiv-issued identifiers for this document.</span></pre><br></td>
+                                                   </tr>
+                                                </table>
+                                             </div>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                    
+                                    <tr>
+                                       <td class="firstColumn"><b>Type</b></td>
+                                       <td><b>object</b></td>
+                                    </tr>
+                                    
+                                    <tr>
+                                       <td class="firstColumn">
+                                          <div class="floatLeft"><b>Properties</b></div>
+                                          <div class="floatRight"><input id="button_properties_#/properties/identifiers" type="image" src="img/btM.gif" value="-" onclick="switchState('properties_#/properties/identifiers');" class="control"></div>
+                                       </td>
+                                       <td>
+                                          <div id="properties_#/properties/identifiers" style="display:block">
+                                             <table class="propertiesTable">
+                                                <tr>
+                                                   <td class="firstColumn" style="white-space: nowrap; font-family: Segoe UI; font-size: 8pt; color: #808080;">Name</td>
+                                                   <td style="font-family: Segoe UI; font-size: 8pt; color: #808080;">
+                                                      Occurrence
+                                                      </td>
+                                                </tr>
+                                                <tr>
+                                                   <td class="firstColumn" style="white-space: nowrap;"><a href="#/properties/identifiers/properties/arxiv_id"><span class="Name">arxiv_id<br></span></a><a href="#/properties/identifiers/properties/arxiv_doi"><span class="Name">arxiv_doi<br></span></a></td>
+                                                   <td><b>required<br>optional<br></b></td>
+                                                </tr>
+                                             </table>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                    
+                                    <tr>
+                                       <td class="firstColumn"><b>Additional Properties</b></td>
+                                       <td>false</td>
+                                    </tr>
+                                    
+                                    <tr>
+                                       <td class="firstColumn">
+                                          <div class="floatLeft"><b>Used by</b></div>
+                                          <div class="floatRight"><input id="button_usedBy_#/properties/identifiers" type="image" src="img/btM.gif" value="-" onclick="switchState('usedBy_#/properties/identifiers');" class="control"></div>
+                                       </td>
+                                       <td>
+                                          <div id="usedBy_#/properties/identifiers" style="display:block">
+                                             <table class="propertiesTable">
+                                                <tr>
+                                                   <td class="firstColumn" style="white-space: nowrap; font-family: Segoe UI; font-size: 8pt; color: #808080;">Schema</td>
+                                                   <tr class="firstColumn" style="white-space: nowrap;">
+                                                      <td><span class="Name"><a href="#/Main Schema">#/Main Schema</a></span></td>
+                                                   </tr>
+                                                </tr>
+                                             </table>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                    
+                                    <tr>
+                                       <td class="firstColumn">
+                                          <div class="floatLeft"><b>Source</b></div>
+                                          <div class="floatRight"><input id="button_source_#/properties/identifiers" type="image" src="img/btM.gif" value="-" onclick="switchState('source_#/properties/identifiers');" class="control"></div>
+                                       </td>
+                                       <td>
+                                          <div id="source_#/properties/identifiers" style="display:block">
+                                             <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
+                                                <tr>
+                                                   <pre><span class="tEl">
+<span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,150)">"identifiers"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"object"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"additionalProperties"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,90)">false</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"arXiv-issued identifiers for this document."</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"required"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">[</span><span style="color: rgb(153,51,0)">"arxiv_id"</span><span style="color: rgb(40,40,40)">]</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"properties"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(0,0,150)">"arxiv_id"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"$ref"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"#/definitions/unversioned_identifier"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"arXiv identifier"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"The canonical arXiv identifier for this document, without a version affix."</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(0,0,150)">"arxiv_doi"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"$ref"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"#/definitions/doi"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"arXiv DOI"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"The arXiv-issued DOI for this document."</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(40,40,40)">}</span><span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"></span>
+
+</span></pre>
+                                                </tr>
+                                             </table>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                    </tbody>
+                              </table>
+                           </td>
+                           <td class="rt_lineRight"></td>
+                        </tr>
+                        <tr>
+                           <td class="rt_cornerBottomLeft"></td>
+                           <td class="rt_lineBottom"></td>
+                           <td class="rt_cornerBottomRight"></td>
+                        </tr>
+                     </table><br><a name="/properties/identifiers/properties/arxiv_id"></a><div class="componentTitle">Definition <a href="#/properties/identifiers/properties/arxiv_id"><span class="Name">arxiv_id</span></a><span class="qname"></span></div>
+                     <table class="rt">
+                        <tr>
+                           <td class="rt_cornerTopLeft"></td>
+                           <td class="rt_lineTop"></td>
+                           <td class="rt_cornerTopRight"></td>
+                        </tr>
+                        <tr>
+                           <td class="rt_lineLeft"></td>
+                           <td class="rt_content">
+                              <table class="component">
+                                 <tbody> 
+                                    
+                                    <tr>
+                                       <td class="firstColumn">
+                                          <div class="floatLeft"><b>Annotations</b></div>
+                                          <div class="floatRight"><input id="button_annotations_#/properties/identifiers/properties/arxiv_id" type="image" src="img/btM.gif" value="-" onclick="switchState('annotations_#/properties/identifiers/properties/arxiv_id');" class="control"></div>
+                                       </td>
+                                       <td>
+                                          <div id="annotations_#/properties/identifiers/properties/arxiv_id" style="display:block">
+                                             <div class="annotation">
+                                                <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
+                                                   <tr>
+                                                      <td width="100%">
+                                                         <pre><span class="DetailName">Title  </span><span class="tT">arXiv identifier</span></pre><br><pre><span class="DetailName">Description  </span><span class="tT">The canonical arXiv identifier for this document, without a version affix.</span></pre>
                                                       </td>
                                                    </tr>
                                                 </table>
@@ -1212,15 +1364,15 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                                     <tr>
                                        <td class="firstColumn">
                                           <div class="floatLeft"><b>Used by</b></div>
-                                          <div class="floatRight"><input id="button_usedBy_#/properties/identifier" type="image" src="img/btM.gif" value="-" onclick="switchState('usedBy_#/properties/identifier');" class="control"></div>
+                                          <div class="floatRight"><input id="button_usedBy_#/properties/identifiers/properties/arxiv_id" type="image" src="img/btM.gif" value="-" onclick="switchState('usedBy_#/properties/identifiers/properties/arxiv_id');" class="control"></div>
                                        </td>
                                        <td>
-                                          <div id="usedBy_#/properties/identifier" style="display:block">
+                                          <div id="usedBy_#/properties/identifiers/properties/arxiv_id" style="display:block">
                                              <table class="propertiesTable">
                                                 <tr>
                                                    <td class="firstColumn" style="white-space: nowrap; font-family: Segoe UI; font-size: 8pt; color: #808080;">Schema</td>
                                                    <tr class="firstColumn" style="white-space: nowrap;">
-                                                      <td><span class="Name"><a href="#/Main Schema">#/Main Schema</a></span></td>
+                                                      <td><span class="Name"><a href="#/properties/identifiers">identifiers</a></span></td>
                                                    </tr>
                                                 </tr>
                                              </table>
@@ -1231,17 +1383,17 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                                     <tr>
                                        <td class="firstColumn">
                                           <div class="floatLeft"><b>Source</b></div>
-                                          <div class="floatRight"><input id="button_source_#/properties/identifier" type="image" src="img/btM.gif" value="-" onclick="switchState('source_#/properties/identifier');" class="control"></div>
+                                          <div class="floatRight"><input id="button_source_#/properties/identifiers/properties/arxiv_id" type="image" src="img/btM.gif" value="-" onclick="switchState('source_#/properties/identifiers/properties/arxiv_id');" class="control"></div>
                                        </td>
                                        <td>
-                                          <div id="source_#/properties/identifier" style="display:block">
+                                          <div id="source_#/properties/identifiers/properties/arxiv_id" style="display:block">
                                              <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
                                                 <tr>
                                                    <pre><span class="tEl">
-<span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,150)">"identifier"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,150)">"arxiv_id"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"$ref"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"#/definitions/unversioned_identifier"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"arXiv identifier"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"Canonical arXiv e-print identifier, without a version affix."</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"The canonical arXiv identifier for this document, without a version affix."</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(40,40,40)">}</span><span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"></span>
 
 </span></pre>
@@ -1260,7 +1412,7 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                            <td class="rt_lineBottom"></td>
                            <td class="rt_cornerBottomRight"></td>
                         </tr>
-                     </table><br><a name="/properties/classifications"></a><div class="componentTitle">Property <a href="#/properties/classifications"><span class="Name">classifications</span></a><span class="qname"></span></div>
+                     </table><br><a name="/properties/identifiers/properties/arxiv_doi"></a><div class="componentTitle">Definition <a href="#/properties/identifiers/properties/arxiv_doi"><span class="Name">arxiv_doi</span></a><span class="qname"></span></div>
                      <table class="rt">
                         <tr>
                            <td class="rt_cornerTopLeft"></td>
@@ -1276,15 +1428,207 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                                     <tr>
                                        <td class="firstColumn">
                                           <div class="floatLeft"><b>Annotations</b></div>
-                                          <div class="floatRight"><input id="button_annotations_#/properties/classifications" type="image" src="img/btM.gif" value="-" onclick="switchState('annotations_#/properties/classifications');" class="control"></div>
+                                          <div class="floatRight"><input id="button_annotations_#/properties/identifiers/properties/arxiv_doi" type="image" src="img/btM.gif" value="-" onclick="switchState('annotations_#/properties/identifiers/properties/arxiv_doi');" class="control"></div>
                                        </td>
                                        <td>
-                                          <div id="annotations_#/properties/classifications" style="display:block">
+                                          <div id="annotations_#/properties/identifiers/properties/arxiv_doi" style="display:block">
                                              <div class="annotation">
                                                 <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
                                                    <tr>
                                                       <td width="100%">
-                                                         <pre><span class="DetailName">Title  </span><span class="tT">Classifications</span></pre><br><pre><span class="DetailName">Description  </span><span class="tT">Primary and optional secondary classifications of this document. Primary must be listed first (0-index); secondaries are unranked.</span></pre>
+                                                         <pre><span class="DetailName">Title  </span><span class="tT">arXiv DOI</span></pre><br><pre><span class="DetailName">Description  </span><span class="tT">The arXiv-issued DOI for this document.</span></pre>
+                                                      </td>
+                                                   </tr>
+                                                </table>
+                                             </div>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                    
+                                    <tr>
+                                       <td class="firstColumn"><b>Type</b></td>
+                                       <td><b>reference</b></td>
+                                    </tr>
+                                    
+                                    <tr>
+                                       <td class="firstColumn"><b>Refers </b></td>
+                                       <td><b><a href="#/definitions/doi">doi</a></b></td>
+                                    </tr>
+                                    
+                                    <tr>
+                                       <td class="firstColumn">
+                                          <div class="floatLeft"><b>Used by</b></div>
+                                          <div class="floatRight"><input id="button_usedBy_#/properties/identifiers/properties/arxiv_doi" type="image" src="img/btM.gif" value="-" onclick="switchState('usedBy_#/properties/identifiers/properties/arxiv_doi');" class="control"></div>
+                                       </td>
+                                       <td>
+                                          <div id="usedBy_#/properties/identifiers/properties/arxiv_doi" style="display:block">
+                                             <table class="propertiesTable">
+                                                <tr>
+                                                   <td class="firstColumn" style="white-space: nowrap; font-family: Segoe UI; font-size: 8pt; color: #808080;">Schema</td>
+                                                   <tr class="firstColumn" style="white-space: nowrap;">
+                                                      <td><span class="Name"><a href="#/properties/identifiers">identifiers</a></span></td>
+                                                   </tr>
+                                                </tr>
+                                             </table>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                    
+                                    <tr>
+                                       <td class="firstColumn">
+                                          <div class="floatLeft"><b>Source</b></div>
+                                          <div class="floatRight"><input id="button_source_#/properties/identifiers/properties/arxiv_doi" type="image" src="img/btM.gif" value="-" onclick="switchState('source_#/properties/identifiers/properties/arxiv_doi');" class="control"></div>
+                                       </td>
+                                       <td>
+                                          <div id="source_#/properties/identifiers/properties/arxiv_doi" style="display:block">
+                                             <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
+                                                <tr>
+                                                   <pre><span class="tEl">
+<span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,150)">"arxiv_doi"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"$ref"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"#/definitions/doi"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"arXiv DOI"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"The arXiv-issued DOI for this document."</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(40,40,40)">}</span><span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"></span>
+
+</span></pre>
+                                                </tr>
+                                             </table>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                    </tbody>
+                              </table>
+                           </td>
+                           <td class="rt_lineRight"></td>
+                        </tr>
+                        <tr>
+                           <td class="rt_cornerBottomLeft"></td>
+                           <td class="rt_lineBottom"></td>
+                           <td class="rt_cornerBottomRight"></td>
+                        </tr>
+                     </table><br><a name="/properties/primary_classification"></a><div class="componentTitle">Definition <a href="#/properties/primary_classification"><span class="Name">primary_classification</span></a><span class="qname"></span></div>
+                     <table class="rt">
+                        <tr>
+                           <td class="rt_cornerTopLeft"></td>
+                           <td class="rt_lineTop"></td>
+                           <td class="rt_cornerTopRight"></td>
+                        </tr>
+                        <tr>
+                           <td class="rt_lineLeft"></td>
+                           <td class="rt_content">
+                              <table class="component">
+                                 <tbody> 
+                                    
+                                    <tr>
+                                       <td class="firstColumn">
+                                          <div class="floatLeft"><b>Annotations</b></div>
+                                          <div class="floatRight"><input id="button_annotations_#/properties/primary_classification" type="image" src="img/btM.gif" value="-" onclick="switchState('annotations_#/properties/primary_classification');" class="control"></div>
+                                       </td>
+                                       <td>
+                                          <div id="annotations_#/properties/primary_classification" style="display:block">
+                                             <div class="annotation">
+                                                <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
+                                                   <tr>
+                                                      <td width="100%">
+                                                         <pre><span class="DetailName">Title  </span><span class="tT">Primary classification</span></pre><br><pre><span class="DetailName">Description  </span><span class="tT">Primary classification of this document.</span></pre>
+                                                      </td>
+                                                   </tr>
+                                                </table>
+                                             </div>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                    
+                                    <tr>
+                                       <td class="firstColumn"><b>Type</b></td>
+                                       <td><b>reference</b></td>
+                                    </tr>
+                                    
+                                    <tr>
+                                       <td class="firstColumn"><b>Refers </b></td>
+                                       <td><b><a href="#/definitions/category">category</a></b></td>
+                                    </tr>
+                                    
+                                    <tr>
+                                       <td class="firstColumn">
+                                          <div class="floatLeft"><b>Used by</b></div>
+                                          <div class="floatRight"><input id="button_usedBy_#/properties/primary_classification" type="image" src="img/btM.gif" value="-" onclick="switchState('usedBy_#/properties/primary_classification');" class="control"></div>
+                                       </td>
+                                       <td>
+                                          <div id="usedBy_#/properties/primary_classification" style="display:block">
+                                             <table class="propertiesTable">
+                                                <tr>
+                                                   <td class="firstColumn" style="white-space: nowrap; font-family: Segoe UI; font-size: 8pt; color: #808080;">Schema</td>
+                                                   <tr class="firstColumn" style="white-space: nowrap;">
+                                                      <td><span class="Name"><a href="#/Main Schema">#/Main Schema</a></span></td>
+                                                   </tr>
+                                                </tr>
+                                             </table>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                    
+                                    <tr>
+                                       <td class="firstColumn">
+                                          <div class="floatLeft"><b>Source</b></div>
+                                          <div class="floatRight"><input id="button_source_#/properties/primary_classification" type="image" src="img/btM.gif" value="-" onclick="switchState('source_#/properties/primary_classification');" class="control"></div>
+                                       </td>
+                                       <td>
+                                          <div id="source_#/properties/primary_classification" style="display:block">
+                                             <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
+                                                <tr>
+                                                   <pre><span class="tEl">
+<span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,150)">"primary_classification"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"$ref"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"#/definitions/category"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"Primary classification"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"Primary classification of this document."</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"examples"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">[</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(153,51,0)">"cs.AI"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(153,51,0)">"hep-th"</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(40,40,40)">]</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(40,40,40)">}</span><span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"></span>
+
+</span></pre>
+                                                </tr>
+                                             </table>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                    </tbody>
+                              </table>
+                           </td>
+                           <td class="rt_lineRight"></td>
+                        </tr>
+                        <tr>
+                           <td class="rt_cornerBottomLeft"></td>
+                           <td class="rt_lineBottom"></td>
+                           <td class="rt_cornerBottomRight"></td>
+                        </tr>
+                     </table><br><a name="/properties/secondary_classifications"></a><div class="componentTitle">Property <a href="#/properties/secondary_classifications"><span class="Name">secondary_classifications</span></a><span class="qname"></span></div>
+                     <table class="rt">
+                        <tr>
+                           <td class="rt_cornerTopLeft"></td>
+                           <td class="rt_lineTop"></td>
+                           <td class="rt_cornerTopRight"></td>
+                        </tr>
+                        <tr>
+                           <td class="rt_lineLeft"></td>
+                           <td class="rt_content">
+                              <table class="component">
+                                 <tbody> 
+                                    
+                                    <tr>
+                                       <td class="firstColumn">
+                                          <div class="floatLeft"><b>Annotations</b></div>
+                                          <div class="floatRight"><input id="button_annotations_#/properties/secondary_classifications" type="image" src="img/btM.gif" value="-" onclick="switchState('annotations_#/properties/secondary_classifications');" class="control"></div>
+                                       </td>
+                                       <td>
+                                          <div id="annotations_#/properties/secondary_classifications" style="display:block">
+                                             <div class="annotation">
+                                                <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
+                                                   <tr>
+                                                      <td width="100%">
+                                                         <pre><span class="DetailName">Title  </span><span class="tT">Secondary classifications</span></pre><br><pre><span class="DetailName">Description  </span><span class="tT">Optional and unranked secondary classifications of this document; sorted alphabetically when displayed.</span></pre>
                                                       </td>
                                                    </tr>
                                                 </table>
@@ -1301,10 +1645,10 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                                     <tr>
                                        <td class="firstColumn">
                                           <div class="floatLeft"><b>Constraints</b></div>
-                                          <div class="floatRight"><input id="button_constraints_#/properties/classifications" type="image" src="img/btM.gif" value="-" onclick="switchState('constraints_#/properties/classifications');" class="control"></div>
+                                          <div class="floatRight"><input id="button_constraints_#/properties/secondary_classifications" type="image" src="img/btM.gif" value="-" onclick="switchState('constraints_#/properties/secondary_classifications');" class="control"></div>
                                        </td>
                                        <td>
-                                          <div id="constraints_#/properties/classifications" style="display:block">
+                                          <div id="constraints_#/properties/secondary_classifications" style="display:block">
                                              <div class="annotation">
                                                 <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
                                                    <tr>
@@ -1328,7 +1672,7 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                                                    <td class="firstColumn" style="white-space: nowrap; font-family: Segoe UI; font-size: 8pt; color: #808080;">Items</td>
                                                 </tr>
                                                 <tr>
-                                                   <td class="firstColumn" style="white-space: nowrap;"><a href="#/properties/classifications/items">#/properties/classifications/items</a></td>
+                                                   <td class="firstColumn" style="white-space: nowrap;"><a href="#/properties/secondary_classifications/items">#/properties/secondary_classifications/items</a></td>
                                                    <td></td>
                                                 </tr>
                                              </table>
@@ -1349,10 +1693,10 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                                     <tr>
                                        <td class="firstColumn">
                                           <div class="floatLeft"><b>Used by</b></div>
-                                          <div class="floatRight"><input id="button_usedBy_#/properties/classifications" type="image" src="img/btM.gif" value="-" onclick="switchState('usedBy_#/properties/classifications');" class="control"></div>
+                                          <div class="floatRight"><input id="button_usedBy_#/properties/secondary_classifications" type="image" src="img/btM.gif" value="-" onclick="switchState('usedBy_#/properties/secondary_classifications');" class="control"></div>
                                        </td>
                                        <td>
-                                          <div id="usedBy_#/properties/classifications" style="display:block">
+                                          <div id="usedBy_#/properties/secondary_classifications" style="display:block">
                                              <table class="propertiesTable">
                                                 <tr>
                                                    <td class="firstColumn" style="white-space: nowrap; font-family: Segoe UI; font-size: 8pt; color: #808080;">Schema</td>
@@ -1368,19 +1712,19 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                                     <tr>
                                        <td class="firstColumn">
                                           <div class="floatLeft"><b>Source</b></div>
-                                          <div class="floatRight"><input id="button_source_#/properties/classifications" type="image" src="img/btM.gif" value="-" onclick="switchState('source_#/properties/classifications');" class="control"></div>
+                                          <div class="floatRight"><input id="button_source_#/properties/secondary_classifications" type="image" src="img/btM.gif" value="-" onclick="switchState('source_#/properties/secondary_classifications');" class="control"></div>
                                        </td>
                                        <td>
-                                          <div id="source_#/properties/classifications" style="display:block">
+                                          <div id="source_#/properties/secondary_classifications" style="display:block">
                                              <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
                                                 <tr>
                                                    <pre><span class="tEl">
-<span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,150)">"classifications"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,150)">"secondary_classifications"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"array"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"uniqueItems"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,90)">true</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"minItems"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,113,227)">1</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"Classifications"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"Primary and optional secondary classifications of this document. Primary must be listed first (0-index); secondaries are unranked."</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"Secondary classifications"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"Optional and unranked secondary classifications of this document; sorted alphabetically when displayed."</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"examples"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">[</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">    </span><span style="color: rgb(40,40,40)">[</span><span style="color: rgb(153,51,0)">"cs.DL"</span><span style="color: rgb(40,40,40)">]</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">    </span><span style="color: rgb(40,40,40)">[</span><span style="color: rgb(0,0,0)"></span>
@@ -1388,7 +1732,6 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
 <span style="color: rgb(0,0,0)">      </span><span style="color: rgb(153,51,0)">"physics.soc-ph"</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">    </span><span style="color: rgb(40,40,40)">]</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">  </span><span style="color: rgb(40,40,40)">]</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"$comment"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"This is an alternative to separate primary and secondary classification fields."</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"items"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,150)">"$ref"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"#/definitions/category"</span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(40,40,40)">}</span><span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"></span>
 
@@ -1408,7 +1751,7 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                            <td class="rt_lineBottom"></td>
                            <td class="rt_cornerBottomRight"></td>
                         </tr>
-                     </table><br><a name="/properties/classifications/items"></a><div class="componentTitle">Definition <a href="#/properties/classifications/items"><span class="Name">classifications/items</span></a><span class="qname"></span></div>
+                     </table><br><a name="/properties/secondary_classifications/items"></a><div class="componentTitle">Definition <a href="#/properties/secondary_classifications/items"><span class="Name">secondary_classifications/items</span></a><span class="qname"></span></div>
                      <table class="rt">
                         <tr>
                            <td class="rt_cornerTopLeft"></td>
@@ -1434,15 +1777,15 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                                     <tr>
                                        <td class="firstColumn">
                                           <div class="floatLeft"><b>Used by</b></div>
-                                          <div class="floatRight"><input id="button_usedBy_#/properties/classifications/items" type="image" src="img/btM.gif" value="-" onclick="switchState('usedBy_#/properties/classifications/items');" class="control"></div>
+                                          <div class="floatRight"><input id="button_usedBy_#/properties/secondary_classifications/items" type="image" src="img/btM.gif" value="-" onclick="switchState('usedBy_#/properties/secondary_classifications/items');" class="control"></div>
                                        </td>
                                        <td>
-                                          <div id="usedBy_#/properties/classifications/items" style="display:block">
+                                          <div id="usedBy_#/properties/secondary_classifications/items" style="display:block">
                                              <table class="propertiesTable">
                                                 <tr>
                                                    <td class="firstColumn" style="white-space: nowrap; font-family: Segoe UI; font-size: 8pt; color: #808080;">Schema</td>
                                                    <tr class="firstColumn" style="white-space: nowrap;">
-                                                      <td><span class="Name"><a href="#/properties/classifications">classifications</a></span></td>
+                                                      <td><span class="Name"><a href="#/properties/secondary_classifications">secondary_classifications</a></span></td>
                                                    </tr>
                                                 </tr>
                                              </table>
@@ -1453,10 +1796,10 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                                     <tr>
                                        <td class="firstColumn">
                                           <div class="floatLeft"><b>Source</b></div>
-                                          <div class="floatRight"><input id="button_source_#/properties/classifications/items" type="image" src="img/btM.gif" value="-" onclick="switchState('source_#/properties/classifications/items');" class="control"></div>
+                                          <div class="floatRight"><input id="button_source_#/properties/secondary_classifications/items" type="image" src="img/btM.gif" value="-" onclick="switchState('source_#/properties/secondary_classifications/items');" class="control"></div>
                                        </td>
                                        <td>
-                                          <div id="source_#/properties/classifications/items" style="display:block">
+                                          <div id="source_#/properties/secondary_classifications/items" style="display:block">
                                              <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
                                                 <tr>
                                                    <pre><span class="tEl">
@@ -1747,10 +2090,10 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                                                 <tr>
                                                    <td class="firstColumn" style="white-space: nowrap; font-family: Segoe UI; font-size: 8pt; color: #808080;">Schema</td>
                                                    <tr class="firstColumn" style="white-space: nowrap;">
-                                                      <td><span class="Name"><a href="#/properties/identifier">identifier</a></span></td>
+                                                      <td><span class="Name"><a href="#/properties/identifiers/properties/arxiv_id">identifiers/properties/arxiv_id</a></span></td>
                                                    </tr>
                                                    <tr class="firstColumn" style="white-space: nowrap;">
-                                                      <td><span class="Name"><a href="#/Main Schema">#/Main Schema</a></span></td>
+                                                      <td><span class="Name"><a href="#/properties/identifiers">identifiers</a></span></td>
                                                    </tr>
                                                 </tr>
                                              </table>
@@ -1772,6 +2115,128 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
 <span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"string"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"pattern"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"^(([0-9]{4}\\.[0-9]{4,5})|([a-z\\-]+\\/[0-9]{2}[01][0-9]{4}))$"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"arXiv canonical identifier"</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(40,40,40)">}</span><span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"></span>
+
+</span></pre>
+                                                </tr>
+                                             </table>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                    </tbody>
+                              </table>
+                           </td>
+                           <td class="rt_lineRight"></td>
+                        </tr>
+                        <tr>
+                           <td class="rt_cornerBottomLeft"></td>
+                           <td class="rt_lineBottom"></td>
+                           <td class="rt_cornerBottomRight"></td>
+                        </tr>
+                     </table><br><a name="/definitions/doi"></a><div class="componentTitle">Definition <a href="#/definitions/doi"><span class="Name">doi</span></a><span class="qname"></span></div>
+                     <table class="rt">
+                        <tr>
+                           <td class="rt_cornerTopLeft"></td>
+                           <td class="rt_lineTop"></td>
+                           <td class="rt_cornerTopRight"></td>
+                        </tr>
+                        <tr>
+                           <td class="rt_lineLeft"></td>
+                           <td class="rt_content">
+                              <table class="component">
+                                 <tbody> 
+                                    
+                                    <tr>
+                                       <td class="firstColumn">
+                                          <div class="floatLeft"><b>Annotations</b></div>
+                                          <div class="floatRight"><input id="button_annotations_#/definitions/doi" type="image" src="img/btM.gif" value="-" onclick="switchState('annotations_#/definitions/doi');" class="control"></div>
+                                       </td>
+                                       <td>
+                                          <div id="annotations_#/definitions/doi" style="display:block">
+                                             <div class="annotation">
+                                                <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
+                                                   <tr>
+                                                      <td width="100%">
+                                                         <pre><span class="DetailName">Title  </span><span class="tT">DOI</span></pre><br><pre><span class="DetailName">Description  </span><span class="tT">Digital Object Identifier.</span></pre>
+                                                      </td>
+                                                   </tr>
+                                                </table>
+                                             </div>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                    
+                                    <tr>
+                                       <td class="firstColumn"><b>Type</b></td>
+                                       <td><b>string</b></td>
+                                    </tr>
+                                    
+                                    <tr>
+                                       <td class="firstColumn">
+                                          <div class="floatLeft"><b>Constraints</b></div>
+                                          <div class="floatRight"><input id="button_constraints_#/definitions/doi" type="image" src="img/btM.gif" value="-" onclick="switchState('constraints_#/definitions/doi');" class="control"></div>
+                                       </td>
+                                       <td>
+                                          <div id="constraints_#/definitions/doi" style="display:block">
+                                             <div class="annotation">
+                                                <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
+                                                   <tr>
+                                                      <td width="100%">
+                                                         <pre><span class="DetailName">Min Length : </span><span class="tT">1</span></pre><br><pre><span class="DetailName">Pattern : </span><span class="tT">^10\.\d+(\.\d+)?/\S+$</span></pre><br></td>
+                                                   </tr>
+                                                </table>
+                                             </div>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                    
+                                    <tr>
+                                       <td class="firstColumn">
+                                          <div class="floatLeft"><b>Used by</b></div>
+                                          <div class="floatRight"><input id="button_usedBy_#/definitions/doi" type="image" src="img/btM.gif" value="-" onclick="switchState('usedBy_#/definitions/doi');" class="control"></div>
+                                       </td>
+                                       <td>
+                                          <div id="usedBy_#/definitions/doi" style="display:block">
+                                             <table class="propertiesTable">
+                                                <tr>
+                                                   <td class="firstColumn" style="white-space: nowrap; font-family: Segoe UI; font-size: 8pt; color: #808080;">Schema</td>
+                                                   <tr class="firstColumn" style="white-space: nowrap;">
+                                                      <td><span class="Name"><a href="#/properties/identifiers/properties/arxiv_doi">identifiers/properties/arxiv_doi</a></span></td>
+                                                   </tr>
+                                                   <tr class="firstColumn" style="white-space: nowrap;">
+                                                      <td><span class="Name"><a href="#/definitions/version/properties/identifiers">version/properties/identifiers</a></span></td>
+                                                   </tr>
+                                                   <tr class="firstColumn" style="white-space: nowrap;">
+                                                      <td><span class="Name"><a href="#/definitions/version/properties/publisher_dois">version/properties/publisher_dois</a></span></td>
+                                                   </tr>
+                                                   <tr class="firstColumn" style="white-space: nowrap;">
+                                                      <td><span class="Name"><a href="#/definitions/version/properties/submitter_dois">version/properties/submitter_dois</a></span></td>
+                                                   </tr>
+                                                   <tr class="firstColumn" style="white-space: nowrap;">
+                                                      <td><span class="Name"><a href="#/properties/identifiers">identifiers</a></span></td>
+                                                   </tr>
+                                                </tr>
+                                             </table>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                    
+                                    <tr>
+                                       <td class="firstColumn">
+                                          <div class="floatLeft"><b>Source</b></div>
+                                          <div class="floatRight"><input id="button_source_#/definitions/doi" type="image" src="img/btM.gif" value="-" onclick="switchState('source_#/definitions/doi');" class="control"></div>
+                                       </td>
+                                       <td>
+                                          <div id="source_#/definitions/doi" style="display:block">
+                                             <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
+                                                <tr>
+                                                   <pre><span class="tEl">
+<span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,150)">"doi"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"string"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"minLength"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,113,227)">1</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"pattern"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"^10\\.\\d+(\\.\\d+)?/\\S+$"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"DOI"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"Digital Object Identifier."</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(40,40,40)">}</span><span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"></span>
 
 </span></pre>
@@ -1858,10 +2323,13 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                                                 <tr>
                                                    <td class="firstColumn" style="white-space: nowrap; font-family: Segoe UI; font-size: 8pt; color: #808080;">Schema</td>
                                                    <tr class="firstColumn" style="white-space: nowrap;">
-                                                      <td><span class="Name"><a href="#/properties/classifications/items">classifications/items</a></span></td>
+                                                      <td><span class="Name"><a href="#/properties/primary_classification">primary_classification</a></span></td>
                                                    </tr>
                                                    <tr class="firstColumn" style="white-space: nowrap;">
-                                                      <td><span class="Name"><a href="#/properties/classifications">classifications</a></span></td>
+                                                      <td><span class="Name"><a href="#/Main Schema">#/Main Schema</a></span></td>
+                                                   </tr>
+                                                   <tr class="firstColumn" style="white-space: nowrap;">
+                                                      <td><span class="Name"><a href="#/properties/secondary_classifications">secondary_classifications</a></span></td>
                                                    </tr>
                                                 </tr>
                                              </table>
@@ -1936,8 +2404,8 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                                                       </td>
                                                 </tr>
                                                 <tr>
-                                                   <td class="firstColumn" style="white-space: nowrap;"><a href="#/definitions/version/properties/identifier"><span class="Name">identifier<br></span></a><a href="#/definitions/version/properties/document_types"><span class="Name">document_types<br></span></a><a href="#/definitions/version/properties/submitter_info"><span class="Name">submitter_info<br></span></a><a href="#/definitions/version/properties/submitted_date"><span class="Name">submitted_date<br></span></a><a href="#/definitions/version/properties/announced_date"><span class="Name">announced_date<br></span></a><a href="#/definitions/version/properties/license"><span class="Name">license<br></span></a><a href="#/definitions/version/properties/titles"><span class="Name">titles<br></span></a><a href="#/definitions/version/properties/abstracts"><span class="Name">abstracts<br></span></a><a href="#/definitions/version/properties/legacy_authors"><span class="Name">legacy_authors<br></span></a><a href="#/definitions/version/properties/authors"><span class="Name">authors<br></span></a><a href="#/definitions/version/properties/collaborations"><span class="Name">collaborations<br></span></a><a href="#/definitions/version/properties/comments"><span class="Name">comments<br></span></a><a href="#/definitions/version/properties/journal_ref"><span class="Name">journal_ref<br></span></a><a href="#/definitions/version/properties/publisher_dois"><span class="Name">publisher_dois<br></span></a><a href="#/definitions/version/properties/submitter_dois"><span class="Name">submitter_dois<br></span></a><a href="#/definitions/version/properties/arxiv_doi"><span class="Name">arxiv_doi<br></span></a><a href="#/definitions/version/properties/report_numbers"><span class="Name">report_numbers<br></span></a><a href="#/definitions/version/properties/msc_classes"><span class="Name">msc_classes<br></span></a><a href="#/definitions/version/properties/keywords"><span class="Name">keywords<br></span></a><a href="#/definitions/version/properties/acm_classes"><span class="Name">acm_classes<br></span></a><a href="#/definitions/version/properties/related_links"><span class="Name">related_links<br></span></a><a href="#/definitions/version/properties/arxiv_status"><span class="Name">arxiv_status<br></span></a><a href="#/definitions/version/properties/external_publication_status"><span class="Name">external_publication_status<br></span></a><a href="#/definitions/version/properties/source_info"><span class="Name">source_info<br></span></a><a href="#/definitions/version/properties/conference_info"><span class="Name">conference_info<br></span></a><a href="#/definitions/version/properties/references"><span class="Name">references<br></span></a></td>
-                                                   <td><b>required<br>required<br>required<br>required<br>required<br>required<br>required<br>required<br>required<br>required<br>optional<br>optional<br>optional<br>optional<br>optional<br>optional<br>optional<br>optional<br>optional<br>optional<br>optional<br>required<br>optional<br>required<br>optional<br>optional<br></b></td>
+                                                   <td class="firstColumn" style="white-space: nowrap;"><a href="#/definitions/version/properties/identifiers"><span class="Name">identifiers<br></span></a><a href="#/definitions/version/properties/document_types"><span class="Name">document_types<br></span></a><a href="#/definitions/version/properties/submitter_info"><span class="Name">submitter_info<br></span></a><a href="#/definitions/version/properties/submitted_date"><span class="Name">submitted_date<br></span></a><a href="#/definitions/version/properties/announced_date"><span class="Name">announced_date<br></span></a><a href="#/definitions/version/properties/license"><span class="Name">license<br></span></a><a href="#/definitions/version/properties/titles"><span class="Name">titles<br></span></a><a href="#/definitions/version/properties/abstracts"><span class="Name">abstracts<br></span></a><a href="#/definitions/version/properties/legacy_authors"><span class="Name">legacy_authors<br></span></a><a href="#/definitions/version/properties/authors"><span class="Name">authors<br></span></a><a href="#/definitions/version/properties/collaborations"><span class="Name">collaborations<br></span></a><a href="#/definitions/version/properties/comments"><span class="Name">comments<br></span></a><a href="#/definitions/version/properties/journal_ref"><span class="Name">journal_ref<br></span></a><a href="#/definitions/version/properties/publisher_dois"><span class="Name">publisher_dois<br></span></a><a href="#/definitions/version/properties/submitter_dois"><span class="Name">submitter_dois<br></span></a><a href="#/definitions/version/properties/report_numbers"><span class="Name">report_numbers<br></span></a><a href="#/definitions/version/properties/keywords"><span class="Name">keywords<br></span></a><a href="#/definitions/version/properties/related_links"><span class="Name">related_links<br></span></a><a href="#/definitions/version/properties/arxiv_status"><span class="Name">arxiv_status<br></span></a><a href="#/definitions/version/properties/external_publication_status"><span class="Name">external_publication_status<br></span></a><a href="#/definitions/version/properties/source_info"><span class="Name">source_info<br></span></a><a href="#/definitions/version/properties/conference_info"><span class="Name">conference_info<br></span></a><a href="#/definitions/version/properties/references"><span class="Name">references<br></span></a></td>
+                                                   <td><b>required<br>required<br>required<br>required<br>required<br>required<br>required<br>required<br>required<br>required<br>optional<br>optional<br>optional<br>optional<br>optional<br>optional<br>optional<br>optional<br>required<br>optional<br>required<br>optional<br>optional<br></b></td>
                                                 </tr>
                                              </table>
                                           </div>
@@ -1985,7 +2453,7 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
 <span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"object"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"additionalProperties"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,90)">false</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"required"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">[</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(153,51,0)">"identifier"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(153,51,0)">"identifiers"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">    </span><span style="color: rgb(153,51,0)">"submitted_date"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">    </span><span style="color: rgb(153,51,0)">"announced_date"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">    </span><span style="color: rgb(153,51,0)">"license"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
@@ -1999,7 +2467,13 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
 <span style="color: rgb(0,0,0)">    </span><span style="color: rgb(153,51,0)">"submitter_info"</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">  </span><span style="color: rgb(40,40,40)">]</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"properties"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(0,0,150)">"identifier"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,150)">"$ref"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"#/definitions/versioned_identifier"</span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(0,0,150)">"identifiers"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"object"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"additionalProperties"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,90)">false</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"arXiv-issued identifiers for this version."</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"required"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">[</span><span style="color: rgb(153,51,0)">"arxiv_idv"</span><span style="color: rgb(40,40,40)">]</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"properties"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">    </span><span style="color: rgb(0,0,150)">"document_types"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"array"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"uniqueItems"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,90)">true</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
@@ -2095,11 +2569,6 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
 <span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"The submitter DOI(s)."</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"items"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">    </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(0,0,150)">"arxiv_doi"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"$ref"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"#/definitions/doi"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"arXiv DOI"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"The arXiv-issued DOI."</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">    </span><span style="color: rgb(0,0,150)">"report_numbers"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"array"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"uniqueItems"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,90)">true</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
@@ -2107,35 +2576,13 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
 <span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"List of report numbers"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"items"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">    </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(0,0,150)">"msc_classes"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"string"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"minLength"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,113,227)">1</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"List of MSC classes"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"Classifications from American Mathematical Society Mathematical Subject Classification (MSC)."</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"examples"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">[</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(153,51,0)">"Primary 14N35, Secondary 14H10, 14H20, 14J26"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(153,51,0)">"Primary 46F30. Secondary: 44A10, 46S10, 46F10, 12J15, 12J25, 16W60"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(153,51,0)">"46B20, 47H10, 54B20, 54F15, 68U05"</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(40,40,40)">]</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"$comment"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"TODO: consider array of an enumerated definition instead. Legacy input is inconsistent."</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">    </span><span style="color: rgb(0,0,150)">"keywords"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"array"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"uniqueItems"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,90)">true</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"minItems"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,113,227)">1</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"List of keywords"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"Keywords may include ACM and MSC subject classes."</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"$comment"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"WIP, consolidate subject classes"</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(0,0,150)">"acm_classes"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"string"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"minLength"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,113,227)">1</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"List of ACM classes"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"Classifications from ACM Computing Classification System."</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"examples"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">[</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(153,51,0)">"C.2.0; C.2.2; C.2.3; C.2.6"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(153,51,0)">"I.3.5"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(153,51,0)">"G.1.6; F.1.1; I.2.6; G.1.3"</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(40,40,40)">]</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"$comment"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"TODO: consider array of an enumerated definition instead. Legacy input is inconsistent."</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"A list of individual keywords that may belong to a vocabulary."</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"items"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">    </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">    </span><span style="color: rgb(0,0,150)">"related_links"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"array"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
@@ -2162,6 +2609,135 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
 <span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"List of references"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"List of unstructured reference strings."</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"items"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(40,40,40)">}</span><span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"></span>
+
+</span></pre>
+                                                </tr>
+                                             </table>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                    </tbody>
+                              </table>
+                           </td>
+                           <td class="rt_lineRight"></td>
+                        </tr>
+                        <tr>
+                           <td class="rt_cornerBottomLeft"></td>
+                           <td class="rt_lineBottom"></td>
+                           <td class="rt_cornerBottomRight"></td>
+                        </tr>
+                     </table><br><a name="/definitions/version/properties/identifiers"></a><div class="componentTitle">Definition <a href="#/definitions/version/properties/identifiers"><span class="Name">identifiers</span></a><span class="qname"></span></div>
+                     <table class="rt">
+                        <tr>
+                           <td class="rt_cornerTopLeft"></td>
+                           <td class="rt_lineTop"></td>
+                           <td class="rt_cornerTopRight"></td>
+                        </tr>
+                        <tr>
+                           <td class="rt_lineLeft"></td>
+                           <td class="rt_content">
+                              <table class="component">
+                                 <tbody> 
+                                    
+                                    <tr>
+                                       <td class="firstColumn">
+                                          <div class="floatLeft"><b>Annotations</b></div>
+                                          <div class="floatRight"><input id="button_annotations_#/definitions/version/properties/identifiers" type="image" src="img/btM.gif" value="-" onclick="switchState('annotations_#/definitions/version/properties/identifiers');" class="control"></div>
+                                       </td>
+                                       <td>
+                                          <div id="annotations_#/definitions/version/properties/identifiers" style="display:block">
+                                             <div class="annotation">
+                                                <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
+                                                   <tr>
+                                                      <td width="100%">
+                                                         <pre><span class="DetailName">Title  </span><span class="tT">arXiv-issued identifiers for this version.</span></pre><br></td>
+                                                   </tr>
+                                                </table>
+                                             </div>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                    
+                                    <tr>
+                                       <td class="firstColumn"><b>Type</b></td>
+                                       <td><b>object</b></td>
+                                    </tr>
+                                    
+                                    <tr>
+                                       <td class="firstColumn">
+                                          <div class="floatLeft"><b>Properties</b></div>
+                                          <div class="floatRight"><input id="button_properties_#/definitions/version/properties/identifiers" type="image" src="img/btM.gif" value="-" onclick="switchState('properties_#/definitions/version/properties/identifiers');" class="control"></div>
+                                       </td>
+                                       <td>
+                                          <div id="properties_#/definitions/version/properties/identifiers" style="display:block">
+                                             <table class="propertiesTable">
+                                                <tr>
+                                                   <td class="firstColumn" style="white-space: nowrap; font-family: Segoe UI; font-size: 8pt; color: #808080;">Name</td>
+                                                   <td style="font-family: Segoe UI; font-size: 8pt; color: #808080;">
+                                                      Occurrence
+                                                      </td>
+                                                </tr>
+                                                <tr>
+                                                   <td class="firstColumn" style="white-space: nowrap;"><a href="#/definitions/version/properties/identifiers/properties/arxiv_idv"><span class="Name">arxiv_idv<br></span></a><a href="#/definitions/version/properties/identifiers/properties/arxiv_doi"><span class="Name">arxiv_doi<br></span></a></td>
+                                                   <td><b>required<br>optional<br></b></td>
+                                                </tr>
+                                             </table>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                    
+                                    <tr>
+                                       <td class="firstColumn"><b>Additional Properties</b></td>
+                                       <td>false</td>
+                                    </tr>
+                                    
+                                    <tr>
+                                       <td class="firstColumn">
+                                          <div class="floatLeft"><b>Used by</b></div>
+                                          <div class="floatRight"><input id="button_usedBy_#/definitions/version/properties/identifiers" type="image" src="img/btM.gif" value="-" onclick="switchState('usedBy_#/definitions/version/properties/identifiers');" class="control"></div>
+                                       </td>
+                                       <td>
+                                          <div id="usedBy_#/definitions/version/properties/identifiers" style="display:block">
+                                             <table class="propertiesTable">
+                                                <tr>
+                                                   <td class="firstColumn" style="white-space: nowrap; font-family: Segoe UI; font-size: 8pt; color: #808080;">Schema</td>
+                                                   <tr class="firstColumn" style="white-space: nowrap;">
+                                                      <td><span class="Name"><a href="#/definitions/version">version</a></span></td>
+                                                   </tr>
+                                                </tr>
+                                             </table>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                    
+                                    <tr>
+                                       <td class="firstColumn">
+                                          <div class="floatLeft"><b>Source</b></div>
+                                          <div class="floatRight"><input id="button_source_#/definitions/version/properties/identifiers" type="image" src="img/btM.gif" value="-" onclick="switchState('source_#/definitions/version/properties/identifiers');" class="control"></div>
+                                       </td>
+                                       <td>
+                                          <div id="source_#/definitions/version/properties/identifiers" style="display:block">
+                                             <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
+                                                <tr>
+                                                   <pre><span class="tEl">
+<span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,150)">"identifiers"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"object"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"additionalProperties"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,90)">false</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"arXiv-issued identifiers for this version."</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"required"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">[</span><span style="color: rgb(153,51,0)">"arxiv_idv"</span><span style="color: rgb(40,40,40)">]</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"properties"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(0,0,150)">"arxiv_idv"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"$ref"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"#/definitions/versioned_identifier"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"arXiv identifier"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"The arXiv identifier for this version, with a version affix."</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(0,0,150)">"arxiv_doi"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"$ref"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"#/definitions/doi"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"arXiv DOI"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"The arXiv-issued DOI for this version."</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">    </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">  </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(40,40,40)">}</span><span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"></span>
@@ -2249,10 +2825,10 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                                                 <tr>
                                                    <td class="firstColumn" style="white-space: nowrap; font-family: Segoe UI; font-size: 8pt; color: #808080;">Schema</td>
                                                    <tr class="firstColumn" style="white-space: nowrap;">
-                                                      <td><span class="Name"><a href="#/definitions/version/properties/identifier">version/properties/identifier</a></span></td>
+                                                      <td><span class="Name"><a href="#/definitions/version/properties/identifiers/properties/arxiv_idv">version/properties/identifiers/properties/arxiv_idv</a></span></td>
                                                    </tr>
                                                    <tr class="firstColumn" style="white-space: nowrap;">
-                                                      <td><span class="Name"><a href="#/definitions/version">version</a></span></td>
+                                                      <td><span class="Name"><a href="#/definitions/version/properties/identifiers">version/properties/identifiers</a></span></td>
                                                    </tr>
                                                 </tr>
                                              </table>
@@ -2292,7 +2868,7 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                            <td class="rt_lineBottom"></td>
                            <td class="rt_cornerBottomRight"></td>
                         </tr>
-                     </table><br><a name="/definitions/version/properties/identifier"></a><div class="componentTitle">Definition <a href="#/definitions/version/properties/identifier"><span class="Name">identifier</span></a><span class="qname"></span></div>
+                     </table><br><a name="/definitions/version/properties/identifiers/properties/arxiv_idv"></a><div class="componentTitle">Definition <a href="#/definitions/version/properties/identifiers/properties/arxiv_idv"><span class="Name">arxiv_idv</span></a><span class="qname"></span></div>
                      <table class="rt">
                         <tr>
                            <td class="rt_cornerTopLeft"></td>
@@ -2304,6 +2880,26 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                            <td class="rt_content">
                               <table class="component">
                                  <tbody> 
+                                    
+                                    <tr>
+                                       <td class="firstColumn">
+                                          <div class="floatLeft"><b>Annotations</b></div>
+                                          <div class="floatRight"><input id="button_annotations_#/definitions/version/properties/identifiers/properties/arxiv_idv" type="image" src="img/btM.gif" value="-" onclick="switchState('annotations_#/definitions/version/properties/identifiers/properties/arxiv_idv');" class="control"></div>
+                                       </td>
+                                       <td>
+                                          <div id="annotations_#/definitions/version/properties/identifiers/properties/arxiv_idv" style="display:block">
+                                             <div class="annotation">
+                                                <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
+                                                   <tr>
+                                                      <td width="100%">
+                                                         <pre><span class="DetailName">Title  </span><span class="tT">arXiv identifier</span></pre><br><pre><span class="DetailName">Description  </span><span class="tT">The arXiv identifier for this version, with a version affix.</span></pre>
+                                                      </td>
+                                                   </tr>
+                                                </table>
+                                             </div>
+                                          </div>
+                                       </td>
+                                    </tr>
                                     
                                     <tr>
                                        <td class="firstColumn"><b>Type</b></td>
@@ -2318,15 +2914,15 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                                     <tr>
                                        <td class="firstColumn">
                                           <div class="floatLeft"><b>Used by</b></div>
-                                          <div class="floatRight"><input id="button_usedBy_#/definitions/version/properties/identifier" type="image" src="img/btM.gif" value="-" onclick="switchState('usedBy_#/definitions/version/properties/identifier');" class="control"></div>
+                                          <div class="floatRight"><input id="button_usedBy_#/definitions/version/properties/identifiers/properties/arxiv_idv" type="image" src="img/btM.gif" value="-" onclick="switchState('usedBy_#/definitions/version/properties/identifiers/properties/arxiv_idv');" class="control"></div>
                                        </td>
                                        <td>
-                                          <div id="usedBy_#/definitions/version/properties/identifier" style="display:block">
+                                          <div id="usedBy_#/definitions/version/properties/identifiers/properties/arxiv_idv" style="display:block">
                                              <table class="propertiesTable">
                                                 <tr>
                                                    <td class="firstColumn" style="white-space: nowrap; font-family: Segoe UI; font-size: 8pt; color: #808080;">Schema</td>
                                                    <tr class="firstColumn" style="white-space: nowrap;">
-                                                      <td><span class="Name"><a href="#/definitions/version">version</a></span></td>
+                                                      <td><span class="Name"><a href="#/definitions/version/properties/identifiers">version/properties/identifiers</a></span></td>
                                                    </tr>
                                                 </tr>
                                              </table>
@@ -2337,14 +2933,112 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                                     <tr>
                                        <td class="firstColumn">
                                           <div class="floatLeft"><b>Source</b></div>
-                                          <div class="floatRight"><input id="button_source_#/definitions/version/properties/identifier" type="image" src="img/btM.gif" value="-" onclick="switchState('source_#/definitions/version/properties/identifier');" class="control"></div>
+                                          <div class="floatRight"><input id="button_source_#/definitions/version/properties/identifiers/properties/arxiv_idv" type="image" src="img/btM.gif" value="-" onclick="switchState('source_#/definitions/version/properties/identifiers/properties/arxiv_idv');" class="control"></div>
                                        </td>
                                        <td>
-                                          <div id="source_#/definitions/version/properties/identifier" style="display:block">
+                                          <div id="source_#/definitions/version/properties/identifiers/properties/arxiv_idv" style="display:block">
                                              <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
                                                 <tr>
                                                    <pre><span class="tEl">
-<span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,150)">"identifier"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,150)">"$ref"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"#/definitions/versioned_identifier"</span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,150)">"arxiv_idv"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"$ref"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"#/definitions/versioned_identifier"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"arXiv identifier"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"The arXiv identifier for this version, with a version affix."</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(40,40,40)">}</span><span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"></span>
+
+</span></pre>
+                                                </tr>
+                                             </table>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                    </tbody>
+                              </table>
+                           </td>
+                           <td class="rt_lineRight"></td>
+                        </tr>
+                        <tr>
+                           <td class="rt_cornerBottomLeft"></td>
+                           <td class="rt_lineBottom"></td>
+                           <td class="rt_cornerBottomRight"></td>
+                        </tr>
+                     </table><br><a name="/definitions/version/properties/identifiers/properties/arxiv_doi"></a><div class="componentTitle">Definition <a href="#/definitions/version/properties/identifiers/properties/arxiv_doi"><span class="Name">arxiv_doi</span></a><span class="qname"></span></div>
+                     <table class="rt">
+                        <tr>
+                           <td class="rt_cornerTopLeft"></td>
+                           <td class="rt_lineTop"></td>
+                           <td class="rt_cornerTopRight"></td>
+                        </tr>
+                        <tr>
+                           <td class="rt_lineLeft"></td>
+                           <td class="rt_content">
+                              <table class="component">
+                                 <tbody> 
+                                    
+                                    <tr>
+                                       <td class="firstColumn">
+                                          <div class="floatLeft"><b>Annotations</b></div>
+                                          <div class="floatRight"><input id="button_annotations_#/definitions/version/properties/identifiers/properties/arxiv_doi" type="image" src="img/btM.gif" value="-" onclick="switchState('annotations_#/definitions/version/properties/identifiers/properties/arxiv_doi');" class="control"></div>
+                                       </td>
+                                       <td>
+                                          <div id="annotations_#/definitions/version/properties/identifiers/properties/arxiv_doi" style="display:block">
+                                             <div class="annotation">
+                                                <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
+                                                   <tr>
+                                                      <td width="100%">
+                                                         <pre><span class="DetailName">Title  </span><span class="tT">arXiv DOI</span></pre><br><pre><span class="DetailName">Description  </span><span class="tT">The arXiv-issued DOI for this version.</span></pre>
+                                                      </td>
+                                                   </tr>
+                                                </table>
+                                             </div>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                    
+                                    <tr>
+                                       <td class="firstColumn"><b>Type</b></td>
+                                       <td><b>reference</b></td>
+                                    </tr>
+                                    
+                                    <tr>
+                                       <td class="firstColumn"><b>Refers </b></td>
+                                       <td><b><a href="#/definitions/doi">doi</a></b></td>
+                                    </tr>
+                                    
+                                    <tr>
+                                       <td class="firstColumn">
+                                          <div class="floatLeft"><b>Used by</b></div>
+                                          <div class="floatRight"><input id="button_usedBy_#/definitions/version/properties/identifiers/properties/arxiv_doi" type="image" src="img/btM.gif" value="-" onclick="switchState('usedBy_#/definitions/version/properties/identifiers/properties/arxiv_doi');" class="control"></div>
+                                       </td>
+                                       <td>
+                                          <div id="usedBy_#/definitions/version/properties/identifiers/properties/arxiv_doi" style="display:block">
+                                             <table class="propertiesTable">
+                                                <tr>
+                                                   <td class="firstColumn" style="white-space: nowrap; font-family: Segoe UI; font-size: 8pt; color: #808080;">Schema</td>
+                                                   <tr class="firstColumn" style="white-space: nowrap;">
+                                                      <td><span class="Name"><a href="#/definitions/version/properties/identifiers">version/properties/identifiers</a></span></td>
+                                                   </tr>
+                                                </tr>
+                                             </table>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                    
+                                    <tr>
+                                       <td class="firstColumn">
+                                          <div class="floatLeft"><b>Source</b></div>
+                                          <div class="floatRight"><input id="button_source_#/definitions/version/properties/identifiers/properties/arxiv_doi" type="image" src="img/btM.gif" value="-" onclick="switchState('source_#/definitions/version/properties/identifiers/properties/arxiv_doi');" class="control"></div>
+                                       </td>
+                                       <td>
+                                          <div id="source_#/definitions/version/properties/identifiers/properties/arxiv_doi" style="display:block">
+                                             <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
+                                                <tr>
+                                                   <pre><span class="tEl">
+<span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,150)">"arxiv_doi"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"$ref"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"#/definitions/doi"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"arXiv DOI"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"The arXiv-issued DOI for this version."</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(40,40,40)">}</span><span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"></span>
 
 </span></pre>
                                                 </tr>
@@ -2887,7 +3581,7 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                                                 </tr>
                                                 <tr>
                                                    <td class="firstColumn" style="white-space: nowrap;"><a href="#/definitions/person/properties/full_name"><span class="Name">full_name<br></span></a><a href="#/definitions/person/properties/last_name"><span class="Name">last_name<br></span></a><a href="#/definitions/person/properties/first_name"><span class="Name">first_name<br></span></a><a href="#/definitions/person/properties/suffix"><span class="Name">suffix<br></span></a><a href="#/definitions/person/properties/affiliations"><span class="Name">affiliations<br></span></a><a href="#/definitions/person/properties/orcid"><span class="Name">orcid<br></span></a><a href="#/definitions/person/properties/author_id"><span class="Name">author_id<br></span></a><a href="#/definitions/person/properties/is_submitter"><span class="Name">is_submitter<br></span></a></td>
-                                                   <td><b>required<br>required<br>optional<br>optional<br>optional<br>optional<br>optional<br>optional<br></b></td>
+                                                   <td><b>required<br>optional<br>optional<br>optional<br>optional<br>optional<br>optional<br>optional<br></b></td>
                                                 </tr>
                                              </table>
                                           </div>
@@ -2937,10 +3631,7 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
 <span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,150)">"person"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"object"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"$comment"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"Removed requirement for first name. Some people do not have a last name--optional too?"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"required"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">[</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(153,51,0)">"full_name"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(153,51,0)">"last_name"</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(40,40,40)">]</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"required"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">[</span><span style="color: rgb(153,51,0)">"full_name"</span><span style="color: rgb(40,40,40)">]</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"properties"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">    </span><span style="color: rgb(0,0,150)">"full_name"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"string"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
@@ -2977,17 +3668,10 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
 <span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"items"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">    </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">    </span><span style="color: rgb(0,0,150)">"orcid"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"string"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"pattern"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"^\\d{4}-\\d{4}-\\d{4}-\\d{3}[0-9X]$"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"ORCID iD"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"allOf"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">[</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">          </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"string"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">          </span><span style="color: rgb(0,0,150)">"pattern"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"^\\d{4}-\\d{4}-\\d{4}-\\d{3}[0-9X]$"</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">          </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"string"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">          </span><span style="color: rgb(0,0,150)">"$comment"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"TODO: consider adding 'orcid' format here; would need to implement validator using checksum method described in https://support.orcid.org/hc/en-us/articles/360006897674-Structure-of-the-ORCID-Identifier"</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(40,40,40)">]</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"$comment"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"TODO: implement custom validator using checksum method described in https://support.orcid.org/hc/en-us/articles/360006897674-Structure-of-the-ORCID-Identifier"</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">    </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">    </span><span style="color: rgb(0,0,150)">"author_id"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"string"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
@@ -4069,34 +4753,26 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                                     
                                     <tr>
                                        <td class="firstColumn"><b>Type</b></td>
-                                       <td><b>object</b></td>
+                                       <td><b>string</b></td>
                                     </tr>
                                     
                                     <tr>
                                        <td class="firstColumn">
-                                          <div class="floatLeft"><b>All of</b></div>
-                                          <div class="floatRight"><input id="button_combined_#/definitions/person/properties/orcid" type="image" src="img/btM.gif" value="-" onclick="switchState('combined_#/definitions/person/properties/orcid');" class="control"></div>
+                                          <div class="floatLeft"><b>Constraints</b></div>
+                                          <div class="floatRight"><input id="button_constraints_#/definitions/person/properties/orcid" type="image" src="img/btM.gif" value="-" onclick="switchState('constraints_#/definitions/person/properties/orcid');" class="control"></div>
                                        </td>
                                        <td>
-                                          <div id="combined_#/definitions/person/properties/orcid" style="display:block">
-                                             <table class="propertiesTable">
-                                                <tr>
-                                                   <td class="firstColumn" style="white-space: nowrap; font-family: Segoe UI; font-size: 8pt; color: #808080;">Choices</td>
-                                                   <tr class="firstColumn" style="white-space: nowrap;">
-                                                      <td><span class="Name"><a href="#/definitions/person/properties/orcid/allOf/0"><b>orcid : Schema (0)</b></a></span></td>
+                                          <div id="constraints_#/definitions/person/properties/orcid" style="display:block">
+                                             <div class="annotation">
+                                                <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
+                                                   <tr>
+                                                      <td width="100%">
+                                                         <pre><span class="DetailName">Pattern : </span><span class="tT">^\d{4}-\d{4}-\d{4}-\d{3}[0-9X]$</span></pre><br></td>
                                                    </tr>
-                                                   <tr class="firstColumn" style="white-space: nowrap;">
-                                                      <td><span class="Name"><a href="#/definitions/person/properties/orcid/allOf/1"><b>orcid : Schema (1)</b></a></span></td>
-                                                   </tr>
-                                                </tr>
-                                             </table>
+                                                </table>
+                                             </div>
                                           </div>
                                        </td>
-                                    </tr>
-                                    
-                                    <tr>
-                                       <td class="firstColumn"><b>Additional Properties</b></td>
-                                       <td>false</td>
                                     </tr>
                                     
                                     <tr>
@@ -4129,173 +4805,11 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                                                 <tr>
                                                    <pre><span class="tEl">
 <span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,150)">"orcid"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"string"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"pattern"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"^\\d{4}-\\d{4}-\\d{4}-\\d{3}[0-9X]$"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"ORCID iD"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"allOf"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">[</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"string"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"pattern"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"^\\d{4}-\\d{4}-\\d{4}-\\d{3}[0-9X]$"</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"string"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"$comment"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"TODO: consider adding 'orcid' format here; would need to implement validator using checksum method described in https://support.orcid.org/hc/en-us/articles/360006897674-Structure-of-the-ORCID-Identifier"</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(40,40,40)">]</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"$comment"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"TODO: implement custom validator using checksum method described in https://support.orcid.org/hc/en-us/articles/360006897674-Structure-of-the-ORCID-Identifier"</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(40,40,40)">}</span><span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"></span>
-
-</span></pre>
-                                                </tr>
-                                             </table>
-                                          </div>
-                                       </td>
-                                    </tr>
-                                    </tbody>
-                              </table>
-                           </td>
-                           <td class="rt_lineRight"></td>
-                        </tr>
-                        <tr>
-                           <td class="rt_cornerBottomLeft"></td>
-                           <td class="rt_lineBottom"></td>
-                           <td class="rt_cornerBottomRight"></td>
-                        </tr>
-                     </table><br><a name="/definitions/person/properties/orcid/allOf/0"></a><div class="componentTitle">Definition <a href="#/definitions/person/properties/orcid/allOf/0"><span class="Name">allOf/0</span></a><span class="qname"></span></div>
-                     <table class="rt">
-                        <tr>
-                           <td class="rt_cornerTopLeft"></td>
-                           <td class="rt_lineTop"></td>
-                           <td class="rt_cornerTopRight"></td>
-                        </tr>
-                        <tr>
-                           <td class="rt_lineLeft"></td>
-                           <td class="rt_content">
-                              <table class="component">
-                                 <tbody> 
-                                    
-                                    <tr>
-                                       <td class="firstColumn"><b>Type</b></td>
-                                       <td><b>string</b></td>
-                                    </tr>
-                                    
-                                    <tr>
-                                       <td class="firstColumn">
-                                          <div class="floatLeft"><b>Constraints</b></div>
-                                          <div class="floatRight"><input id="button_constraints_#/definitions/person/properties/orcid/allOf/0" type="image" src="img/btM.gif" value="-" onclick="switchState('constraints_#/definitions/person/properties/orcid/allOf/0');" class="control"></div>
-                                       </td>
-                                       <td>
-                                          <div id="constraints_#/definitions/person/properties/orcid/allOf/0" style="display:block">
-                                             <div class="annotation">
-                                                <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
-                                                   <tr>
-                                                      <td width="100%">
-                                                         <pre><span class="DetailName">Pattern : </span><span class="tT">^\d{4}-\d{4}-\d{4}-\d{3}[0-9X]$</span></pre><br></td>
-                                                   </tr>
-                                                </table>
-                                             </div>
-                                          </div>
-                                       </td>
-                                    </tr>
-                                    
-                                    <tr>
-                                       <td class="firstColumn">
-                                          <div class="floatLeft"><b>Used by</b></div>
-                                          <div class="floatRight"><input id="button_usedBy_#/definitions/person/properties/orcid/allOf/0" type="image" src="img/btM.gif" value="-" onclick="switchState('usedBy_#/definitions/person/properties/orcid/allOf/0');" class="control"></div>
-                                       </td>
-                                       <td>
-                                          <div id="usedBy_#/definitions/person/properties/orcid/allOf/0" style="display:block">
-                                             <table class="propertiesTable">
-                                                <tr>
-                                                   <td class="firstColumn" style="white-space: nowrap; font-family: Segoe UI; font-size: 8pt; color: #808080;">Schema</td>
-                                                   <tr class="firstColumn" style="white-space: nowrap;">
-                                                      <td><span class="Name"><a href="#/definitions/person/properties/orcid">person/properties/orcid</a></span></td>
-                                                   </tr>
-                                                </tr>
-                                             </table>
-                                          </div>
-                                       </td>
-                                    </tr>
-                                    
-                                    <tr>
-                                       <td class="firstColumn">
-                                          <div class="floatLeft"><b>Source</b></div>
-                                          <div class="floatRight"><input id="button_source_#/definitions/person/properties/orcid/allOf/0" type="image" src="img/btM.gif" value="-" onclick="switchState('source_#/definitions/person/properties/orcid/allOf/0');" class="control"></div>
-                                       </td>
-                                       <td>
-                                          <div id="source_#/definitions/person/properties/orcid/allOf/0" style="display:block">
-                                             <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
-                                                <tr>
-                                                   <pre><span class="tEl">
-<span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"string"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"pattern"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"^\\d{4}-\\d{4}-\\d{4}-\\d{3}[0-9X]$"</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(40,40,40)">}</span><span style="color: rgb(0,0,0)"></span>
-
-</span></pre>
-                                                </tr>
-                                             </table>
-                                          </div>
-                                       </td>
-                                    </tr>
-                                    </tbody>
-                              </table>
-                           </td>
-                           <td class="rt_lineRight"></td>
-                        </tr>
-                        <tr>
-                           <td class="rt_cornerBottomLeft"></td>
-                           <td class="rt_lineBottom"></td>
-                           <td class="rt_cornerBottomRight"></td>
-                        </tr>
-                     </table><br><a name="/definitions/person/properties/orcid/allOf/1"></a><div class="componentTitle">Definition <a href="#/definitions/person/properties/orcid/allOf/1"><span class="Name">allOf/1</span></a><span class="qname"></span></div>
-                     <table class="rt">
-                        <tr>
-                           <td class="rt_cornerTopLeft"></td>
-                           <td class="rt_lineTop"></td>
-                           <td class="rt_cornerTopRight"></td>
-                        </tr>
-                        <tr>
-                           <td class="rt_lineLeft"></td>
-                           <td class="rt_content">
-                              <table class="component">
-                                 <tbody> 
-                                    
-                                    <tr>
-                                       <td class="firstColumn"><b>Type</b></td>
-                                       <td><b>string</b></td>
-                                    </tr>
-                                    
-                                    <tr>
-                                       <td class="firstColumn">
-                                          <div class="floatLeft"><b>Used by</b></div>
-                                          <div class="floatRight"><input id="button_usedBy_#/definitions/person/properties/orcid/allOf/1" type="image" src="img/btM.gif" value="-" onclick="switchState('usedBy_#/definitions/person/properties/orcid/allOf/1');" class="control"></div>
-                                       </td>
-                                       <td>
-                                          <div id="usedBy_#/definitions/person/properties/orcid/allOf/1" style="display:block">
-                                             <table class="propertiesTable">
-                                                <tr>
-                                                   <td class="firstColumn" style="white-space: nowrap; font-family: Segoe UI; font-size: 8pt; color: #808080;">Schema</td>
-                                                   <tr class="firstColumn" style="white-space: nowrap;">
-                                                      <td><span class="Name"><a href="#/definitions/person/properties/orcid">person/properties/orcid</a></span></td>
-                                                   </tr>
-                                                </tr>
-                                             </table>
-                                          </div>
-                                       </td>
-                                    </tr>
-                                    
-                                    <tr>
-                                       <td class="firstColumn">
-                                          <div class="floatLeft"><b>Source</b></div>
-                                          <div class="floatRight"><input id="button_source_#/definitions/person/properties/orcid/allOf/1" type="image" src="img/btM.gif" value="-" onclick="switchState('source_#/definitions/person/properties/orcid/allOf/1');" class="control"></div>
-                                       </td>
-                                       <td>
-                                          <div id="source_#/definitions/person/properties/orcid/allOf/1" style="display:block">
-                                             <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
-                                                <tr>
-                                                   <pre><span class="tEl">
-<span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"string"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"$comment"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"TODO: consider adding 'orcid' format here; would need to implement validator using checksum method described in https://support.orcid.org/hc/en-us/articles/360006897674-Structure-of-the-ORCID-Identifier"</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(40,40,40)">}</span><span style="color: rgb(0,0,0)"></span>
 
 </span></pre>
                                                 </tr>
@@ -9209,125 +9723,6 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                            <td class="rt_lineBottom"></td>
                            <td class="rt_cornerBottomRight"></td>
                         </tr>
-                     </table><br><a name="/definitions/doi"></a><div class="componentTitle">Definition <a href="#/definitions/doi"><span class="Name">doi</span></a><span class="qname"></span></div>
-                     <table class="rt">
-                        <tr>
-                           <td class="rt_cornerTopLeft"></td>
-                           <td class="rt_lineTop"></td>
-                           <td class="rt_cornerTopRight"></td>
-                        </tr>
-                        <tr>
-                           <td class="rt_lineLeft"></td>
-                           <td class="rt_content">
-                              <table class="component">
-                                 <tbody> 
-                                    
-                                    <tr>
-                                       <td class="firstColumn">
-                                          <div class="floatLeft"><b>Annotations</b></div>
-                                          <div class="floatRight"><input id="button_annotations_#/definitions/doi" type="image" src="img/btM.gif" value="-" onclick="switchState('annotations_#/definitions/doi');" class="control"></div>
-                                       </td>
-                                       <td>
-                                          <div id="annotations_#/definitions/doi" style="display:block">
-                                             <div class="annotation">
-                                                <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
-                                                   <tr>
-                                                      <td width="100%">
-                                                         <pre><span class="DetailName">Title  </span><span class="tT">DOI</span></pre><br><pre><span class="DetailName">Description  </span><span class="tT">Digital Object Identifier.</span></pre>
-                                                      </td>
-                                                   </tr>
-                                                </table>
-                                             </div>
-                                          </div>
-                                       </td>
-                                    </tr>
-                                    
-                                    <tr>
-                                       <td class="firstColumn"><b>Type</b></td>
-                                       <td><b>string</b></td>
-                                    </tr>
-                                    
-                                    <tr>
-                                       <td class="firstColumn">
-                                          <div class="floatLeft"><b>Constraints</b></div>
-                                          <div class="floatRight"><input id="button_constraints_#/definitions/doi" type="image" src="img/btM.gif" value="-" onclick="switchState('constraints_#/definitions/doi');" class="control"></div>
-                                       </td>
-                                       <td>
-                                          <div id="constraints_#/definitions/doi" style="display:block">
-                                             <div class="annotation">
-                                                <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
-                                                   <tr>
-                                                      <td width="100%">
-                                                         <pre><span class="DetailName">Min Length : </span><span class="tT">1</span></pre><br><pre><span class="DetailName">Pattern : </span><span class="tT">^10\.\d+(\.\d+)?/\S+$</span></pre><br></td>
-                                                   </tr>
-                                                </table>
-                                             </div>
-                                          </div>
-                                       </td>
-                                    </tr>
-                                    
-                                    <tr>
-                                       <td class="firstColumn">
-                                          <div class="floatLeft"><b>Used by</b></div>
-                                          <div class="floatRight"><input id="button_usedBy_#/definitions/doi" type="image" src="img/btM.gif" value="-" onclick="switchState('usedBy_#/definitions/doi');" class="control"></div>
-                                       </td>
-                                       <td>
-                                          <div id="usedBy_#/definitions/doi" style="display:block">
-                                             <table class="propertiesTable">
-                                                <tr>
-                                                   <td class="firstColumn" style="white-space: nowrap; font-family: Segoe UI; font-size: 8pt; color: #808080;">Schema</td>
-                                                   <tr class="firstColumn" style="white-space: nowrap;">
-                                                      <td><span class="Name"><a href="#/definitions/version/properties/publisher_dois/items">version/properties/publisher_dois/items</a></span></td>
-                                                   </tr>
-                                                   <tr class="firstColumn" style="white-space: nowrap;">
-                                                      <td><span class="Name"><a href="#/definitions/version">version</a></span></td>
-                                                   </tr>
-                                                   <tr class="firstColumn" style="white-space: nowrap;">
-                                                      <td><span class="Name"><a href="#/definitions/version/properties/publisher_dois">version/properties/publisher_dois</a></span></td>
-                                                   </tr>
-                                                   <tr class="firstColumn" style="white-space: nowrap;">
-                                                      <td><span class="Name"><a href="#/definitions/version/properties/submitter_dois">version/properties/submitter_dois</a></span></td>
-                                                   </tr>
-                                                </tr>
-                                             </table>
-                                          </div>
-                                       </td>
-                                    </tr>
-                                    
-                                    <tr>
-                                       <td class="firstColumn">
-                                          <div class="floatLeft"><b>Source</b></div>
-                                          <div class="floatRight"><input id="button_source_#/definitions/doi" type="image" src="img/btM.gif" value="-" onclick="switchState('source_#/definitions/doi');" class="control"></div>
-                                       </td>
-                                       <td>
-                                          <div id="source_#/definitions/doi" style="display:block">
-                                             <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
-                                                <tr>
-                                                   <pre><span class="tEl">
-<span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,150)">"doi"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"string"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"minLength"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,113,227)">1</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"pattern"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"^10\\.\\d+(\\.\\d+)?/\\S+$"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"DOI"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"Digital Object Identifier."</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(40,40,40)">}</span><span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"></span>
-
-</span></pre>
-                                                </tr>
-                                             </table>
-                                          </div>
-                                       </td>
-                                    </tr>
-                                    </tbody>
-                              </table>
-                           </td>
-                           <td class="rt_lineRight"></td>
-                        </tr>
-                        <tr>
-                           <td class="rt_cornerBottomLeft"></td>
-                           <td class="rt_lineBottom"></td>
-                           <td class="rt_cornerBottomRight"></td>
-                        </tr>
                      </table><br><a name="/definitions/version/properties/publisher_dois/items"></a><div class="componentTitle">Definition <a href="#/definitions/version/properties/publisher_dois/items"><span class="Name">publisher_dois/items</span></a><span class="qname"></span></div>
                      <table class="rt">
                         <tr>
@@ -9603,100 +9998,6 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                            <td class="rt_lineBottom"></td>
                            <td class="rt_cornerBottomRight"></td>
                         </tr>
-                     </table><br><a name="/definitions/version/properties/arxiv_doi"></a><div class="componentTitle">Definition <a href="#/definitions/version/properties/arxiv_doi"><span class="Name">arxiv_doi</span></a><span class="qname"></span></div>
-                     <table class="rt">
-                        <tr>
-                           <td class="rt_cornerTopLeft"></td>
-                           <td class="rt_lineTop"></td>
-                           <td class="rt_cornerTopRight"></td>
-                        </tr>
-                        <tr>
-                           <td class="rt_lineLeft"></td>
-                           <td class="rt_content">
-                              <table class="component">
-                                 <tbody> 
-                                    
-                                    <tr>
-                                       <td class="firstColumn">
-                                          <div class="floatLeft"><b>Annotations</b></div>
-                                          <div class="floatRight"><input id="button_annotations_#/definitions/version/properties/arxiv_doi" type="image" src="img/btM.gif" value="-" onclick="switchState('annotations_#/definitions/version/properties/arxiv_doi');" class="control"></div>
-                                       </td>
-                                       <td>
-                                          <div id="annotations_#/definitions/version/properties/arxiv_doi" style="display:block">
-                                             <div class="annotation">
-                                                <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
-                                                   <tr>
-                                                      <td width="100%">
-                                                         <pre><span class="DetailName">Title  </span><span class="tT">arXiv DOI</span></pre><br><pre><span class="DetailName">Description  </span><span class="tT">The arXiv-issued DOI.</span></pre>
-                                                      </td>
-                                                   </tr>
-                                                </table>
-                                             </div>
-                                          </div>
-                                       </td>
-                                    </tr>
-                                    
-                                    <tr>
-                                       <td class="firstColumn"><b>Type</b></td>
-                                       <td><b>reference</b></td>
-                                    </tr>
-                                    
-                                    <tr>
-                                       <td class="firstColumn"><b>Refers </b></td>
-                                       <td><b><a href="#/definitions/doi">doi</a></b></td>
-                                    </tr>
-                                    
-                                    <tr>
-                                       <td class="firstColumn">
-                                          <div class="floatLeft"><b>Used by</b></div>
-                                          <div class="floatRight"><input id="button_usedBy_#/definitions/version/properties/arxiv_doi" type="image" src="img/btM.gif" value="-" onclick="switchState('usedBy_#/definitions/version/properties/arxiv_doi');" class="control"></div>
-                                       </td>
-                                       <td>
-                                          <div id="usedBy_#/definitions/version/properties/arxiv_doi" style="display:block">
-                                             <table class="propertiesTable">
-                                                <tr>
-                                                   <td class="firstColumn" style="white-space: nowrap; font-family: Segoe UI; font-size: 8pt; color: #808080;">Schema</td>
-                                                   <tr class="firstColumn" style="white-space: nowrap;">
-                                                      <td><span class="Name"><a href="#/definitions/version">version</a></span></td>
-                                                   </tr>
-                                                </tr>
-                                             </table>
-                                          </div>
-                                       </td>
-                                    </tr>
-                                    
-                                    <tr>
-                                       <td class="firstColumn">
-                                          <div class="floatLeft"><b>Source</b></div>
-                                          <div class="floatRight"><input id="button_source_#/definitions/version/properties/arxiv_doi" type="image" src="img/btM.gif" value="-" onclick="switchState('source_#/definitions/version/properties/arxiv_doi');" class="control"></div>
-                                       </td>
-                                       <td>
-                                          <div id="source_#/definitions/version/properties/arxiv_doi" style="display:block">
-                                             <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
-                                                <tr>
-                                                   <pre><span class="tEl">
-<span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,150)">"arxiv_doi"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"$ref"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"#/definitions/doi"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"arXiv DOI"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"The arXiv-issued DOI."</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(40,40,40)">}</span><span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"></span>
-
-</span></pre>
-                                                </tr>
-                                             </table>
-                                          </div>
-                                       </td>
-                                    </tr>
-                                    </tbody>
-                              </table>
-                           </td>
-                           <td class="rt_lineRight"></td>
-                        </tr>
-                        <tr>
-                           <td class="rt_cornerBottomLeft"></td>
-                           <td class="rt_lineBottom"></td>
-                           <td class="rt_cornerBottomRight"></td>
-                        </tr>
                      </table><br><a name="/definitions/version/properties/report_numbers"></a><div class="componentTitle">Definition <a href="#/definitions/version/properties/report_numbers"><span class="Name">report_numbers</span></a><span class="qname"></span></div>
                      <table class="rt">
                         <tr>
@@ -9920,127 +10221,6 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                            <td class="rt_lineBottom"></td>
                            <td class="rt_cornerBottomRight"></td>
                         </tr>
-                     </table><br><a name="/definitions/version/properties/msc_classes"></a><div class="componentTitle">Definition <a href="#/definitions/version/properties/msc_classes"><span class="Name">msc_classes</span></a><span class="qname"></span></div>
-                     <table class="rt">
-                        <tr>
-                           <td class="rt_cornerTopLeft"></td>
-                           <td class="rt_lineTop"></td>
-                           <td class="rt_cornerTopRight"></td>
-                        </tr>
-                        <tr>
-                           <td class="rt_lineLeft"></td>
-                           <td class="rt_content">
-                              <table class="component">
-                                 <tbody> 
-                                    
-                                    <tr>
-                                       <td class="firstColumn">
-                                          <div class="floatLeft"><b>Annotations</b></div>
-                                          <div class="floatRight"><input id="button_annotations_#/definitions/version/properties/msc_classes" type="image" src="img/btM.gif" value="-" onclick="switchState('annotations_#/definitions/version/properties/msc_classes');" class="control"></div>
-                                       </td>
-                                       <td>
-                                          <div id="annotations_#/definitions/version/properties/msc_classes" style="display:block">
-                                             <div class="annotation">
-                                                <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
-                                                   <tr>
-                                                      <td width="100%">
-                                                         <pre><span class="DetailName">Title  </span><span class="tT">List of MSC classes</span></pre><br><pre><span class="DetailName">Description  </span><span class="tT">Classifications from American Mathematical Society Mathematical Subject Classification (MSC).</span></pre>
-                                                      </td>
-                                                   </tr>
-                                                </table>
-                                             </div>
-                                          </div>
-                                       </td>
-                                    </tr>
-                                    
-                                    <tr>
-                                       <td class="firstColumn"><b>Type</b></td>
-                                       <td><b>string</b></td>
-                                    </tr>
-                                    
-                                    <tr>
-                                       <td class="firstColumn">
-                                          <div class="floatLeft"><b>Constraints</b></div>
-                                          <div class="floatRight"><input id="button_constraints_#/definitions/version/properties/msc_classes" type="image" src="img/btM.gif" value="-" onclick="switchState('constraints_#/definitions/version/properties/msc_classes');" class="control"></div>
-                                       </td>
-                                       <td>
-                                          <div id="constraints_#/definitions/version/properties/msc_classes" style="display:block">
-                                             <div class="annotation">
-                                                <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
-                                                   <tr>
-                                                      <td width="100%">
-                                                         <pre><span class="DetailName">Min Length : </span><span class="tT">1</span></pre><br></td>
-                                                   </tr>
-                                                </table>
-                                             </div>
-                                          </div>
-                                       </td>
-                                    </tr>
-                                    
-                                    <tr>
-                                       <td class="firstColumn"><b>Examples</b></td>
-                                       <td><b>Primary 14N35  Secondary 14H10  14H20  14J26  Primary 46F30. Secondary: 44A10  46S10
-                                             46F10  12J15  12J25  16W60  46B20  47H10  54B20  54F15  68U05</b></td>
-                                    </tr>
-                                    
-                                    <tr>
-                                       <td class="firstColumn">
-                                          <div class="floatLeft"><b>Used by</b></div>
-                                          <div class="floatRight"><input id="button_usedBy_#/definitions/version/properties/msc_classes" type="image" src="img/btM.gif" value="-" onclick="switchState('usedBy_#/definitions/version/properties/msc_classes');" class="control"></div>
-                                       </td>
-                                       <td>
-                                          <div id="usedBy_#/definitions/version/properties/msc_classes" style="display:block">
-                                             <table class="propertiesTable">
-                                                <tr>
-                                                   <td class="firstColumn" style="white-space: nowrap; font-family: Segoe UI; font-size: 8pt; color: #808080;">Schema</td>
-                                                   <tr class="firstColumn" style="white-space: nowrap;">
-                                                      <td><span class="Name"><a href="#/definitions/version">version</a></span></td>
-                                                   </tr>
-                                                </tr>
-                                             </table>
-                                          </div>
-                                       </td>
-                                    </tr>
-                                    
-                                    <tr>
-                                       <td class="firstColumn">
-                                          <div class="floatLeft"><b>Source</b></div>
-                                          <div class="floatRight"><input id="button_source_#/definitions/version/properties/msc_classes" type="image" src="img/btM.gif" value="-" onclick="switchState('source_#/definitions/version/properties/msc_classes');" class="control"></div>
-                                       </td>
-                                       <td>
-                                          <div id="source_#/definitions/version/properties/msc_classes" style="display:block">
-                                             <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
-                                                <tr>
-                                                   <pre><span class="tEl">
-<span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,150)">"msc_classes"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"string"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"minLength"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,113,227)">1</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"List of MSC classes"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"Classifications from American Mathematical Society Mathematical Subject Classification (MSC)."</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"examples"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">[</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(153,51,0)">"Primary 14N35, Secondary 14H10, 14H20, 14J26"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(153,51,0)">"Primary 46F30. Secondary: 44A10, 46S10, 46F10, 12J15, 12J25, 16W60"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(153,51,0)">"46B20, 47H10, 54B20, 54F15, 68U05"</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(40,40,40)">]</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"$comment"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"TODO: consider array of an enumerated definition instead. Legacy input is inconsistent."</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(40,40,40)">}</span><span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"></span>
-
-</span></pre>
-                                                </tr>
-                                             </table>
-                                          </div>
-                                       </td>
-                                    </tr>
-                                    </tbody>
-                              </table>
-                           </td>
-                           <td class="rt_lineRight"></td>
-                        </tr>
-                        <tr>
-                           <td class="rt_cornerBottomLeft"></td>
-                           <td class="rt_lineBottom"></td>
-                           <td class="rt_cornerBottomRight"></td>
-                        </tr>
                      </table><br><a name="/definitions/version/properties/keywords"></a><div class="componentTitle">Definition <a href="#/definitions/version/properties/keywords"><span class="Name">keywords</span></a><span class="qname"></span></div>
                      <table class="rt">
                         <tr>
@@ -10065,7 +10245,7 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                                                 <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
                                                    <tr>
                                                       <td width="100%">
-                                                         <pre><span class="DetailName">Title  </span><span class="tT">List of keywords</span></pre><br><pre><span class="DetailName">Description  </span><span class="tT">Keywords may include ACM and MSC subject classes.</span></pre>
+                                                         <pre><span class="DetailName">Title  </span><span class="tT">List of keywords</span></pre><br><pre><span class="DetailName">Description  </span><span class="tT">A list of individual keywords that may belong to a vocabulary.</span></pre>
                                                       </td>
                                                    </tr>
                                                 </table>
@@ -10090,10 +10270,29 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                                                 <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
                                                    <tr>
                                                       <td width="100%">
-                                                         <pre><span class="DetailName">Unique Items : </span><span class="tT">false</span></pre><br></td>
+                                                         <pre><span class="DetailName">Unique Items : </span><span class="tT">true</span></pre><br></td>
                                                    </tr>
                                                 </table>
                                              </div>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                    
+                                    <tr>
+                                       <td class="firstColumn">
+                                          <div class="floatLeft"><b>Array Items</b></div>
+                                       </td>
+                                       <td>
+                                          <div id="propertyDependencies" style="display:block">
+                                             <table class="propertiesTable">
+                                                <tr>
+                                                   <td class="firstColumn" style="white-space: nowrap; font-family: Segoe UI; font-size: 8pt; color: #808080;">Items</td>
+                                                </tr>
+                                                <tr>
+                                                   <td class="firstColumn" style="white-space: nowrap;"><a href="#/definitions/version/properties/keywords/items">#/definitions/version/properties/keywords/items</a></td>
+                                                   <td></td>
+                                                </tr>
+                                             </table>
                                           </div>
                                        </td>
                                     </tr>
@@ -10134,9 +10333,55 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                                                    <pre><span class="tEl">
 <span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,150)">"keywords"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"array"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"uniqueItems"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,90)">true</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"minItems"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,113,227)">1</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"List of keywords"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"Keywords may include ACM and MSC subject classes."</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"$comment"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"WIP, consolidate subject classes"</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"A list of individual keywords that may belong to a vocabulary."</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"items"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"object"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(0,0,150)">"additionalProperties"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,90)">false</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(0,0,150)">"examples"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">[</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(40,40,40)">[</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">          </span><span style="color: rgb(0,0,150)">"vocabulary"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"ACM"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">          </span><span style="color: rgb(0,0,150)">"value"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"C.2.0;"</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">          </span><span style="color: rgb(0,0,150)">"vocabulary"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"ACM"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">          </span><span style="color: rgb(0,0,150)">"value"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"C.2.2"</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(40,40,40)">]</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(40,40,40)">[</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">          </span><span style="color: rgb(0,0,150)">"vocabulary"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"MSC"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">          </span><span style="color: rgb(0,0,150)">"value"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"46B20"</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(40,40,40)">]</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(40,40,40)">]</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(0,0,150)">"required"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">[</span><span style="color: rgb(153,51,0)">"value"</span><span style="color: rgb(40,40,40)">]</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(0,0,150)">"properties"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"vocabulary"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"Keyword vocabulary"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"The keyword vocabulary this keyword belongs to."</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"string"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(0,0,150)">"enum"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">[</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">          </span><span style="color: rgb(153,51,0)">"PDG"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">          </span><span style="color: rgb(153,51,0)">"PACS"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">          </span><span style="color: rgb(153,51,0)">"JACOW"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">          </span><span style="color: rgb(153,51,0)">"UAT"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">          </span><span style="color: rgb(153,51,0)">"ACM"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">          </span><span style="color: rgb(153,51,0)">"MSC"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">          </span><span style="color: rgb(153,51,0)">"INIS"</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(40,40,40)">]</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"value"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"string"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(0,0,150)">"minLength"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,113,227)">1</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"Keyword"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"A keyword that is either part of a vocabulary or free-form."</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(40,40,40)">}</span><span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"></span>
 
 </span></pre>
@@ -10155,7 +10400,149 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                            <td class="rt_lineBottom"></td>
                            <td class="rt_cornerBottomRight"></td>
                         </tr>
-                     </table><br><a name="/definitions/version/properties/acm_classes"></a><div class="componentTitle">Definition <a href="#/definitions/version/properties/acm_classes"><span class="Name">acm_classes</span></a><span class="qname"></span></div>
+                     </table><br><a name="/definitions/version/properties/keywords/items"></a><div class="componentTitle">Definition <a href="#/definitions/version/properties/keywords/items"><span class="Name">keywords/items</span></a><span class="qname"></span></div>
+                     <table class="rt">
+                        <tr>
+                           <td class="rt_cornerTopLeft"></td>
+                           <td class="rt_lineTop"></td>
+                           <td class="rt_cornerTopRight"></td>
+                        </tr>
+                        <tr>
+                           <td class="rt_lineLeft"></td>
+                           <td class="rt_content">
+                              <table class="component">
+                                 <tbody> 
+                                    
+                                    <tr>
+                                       <td class="firstColumn"><b>Type</b></td>
+                                       <td><b>object</b></td>
+                                    </tr>
+                                    
+                                    <tr>
+                                       <td class="firstColumn">
+                                          <div class="floatLeft"><b>Properties</b></div>
+                                          <div class="floatRight"><input id="button_properties_#/definitions/version/properties/keywords/items" type="image" src="img/btM.gif" value="-" onclick="switchState('properties_#/definitions/version/properties/keywords/items');" class="control"></div>
+                                       </td>
+                                       <td>
+                                          <div id="properties_#/definitions/version/properties/keywords/items" style="display:block">
+                                             <table class="propertiesTable">
+                                                <tr>
+                                                   <td class="firstColumn" style="white-space: nowrap; font-family: Segoe UI; font-size: 8pt; color: #808080;">Name</td>
+                                                   <td style="font-family: Segoe UI; font-size: 8pt; color: #808080;">
+                                                      Occurrence
+                                                      </td>
+                                                </tr>
+                                                <tr>
+                                                   <td class="firstColumn" style="white-space: nowrap;"><a href="#/definitions/version/properties/keywords/items/properties/vocabulary"><span class="Name">vocabulary<br></span></a><a href="#/definitions/version/properties/keywords/items/properties/value"><span class="Name">value<br></span></a></td>
+                                                   <td><b>optional<br>required<br></b></td>
+                                                </tr>
+                                             </table>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                    
+                                    <tr>
+                                       <td class="firstColumn"><b>Additional Properties</b></td>
+                                       <td>false</td>
+                                    </tr>
+                                    
+                                    <tr>
+                                       <td class="firstColumn"><b>Examples</b></td>
+                                       <td><b>[{vocabulary=ACM  value=C.2.0;}  {vocabulary=ACM  value=C.2.2}</b></td>
+                                    </tr>
+                                    
+                                    <tr>
+                                       <td class="firstColumn">
+                                          <div class="floatLeft"><b>Used by</b></div>
+                                          <div class="floatRight"><input id="button_usedBy_#/definitions/version/properties/keywords/items" type="image" src="img/btM.gif" value="-" onclick="switchState('usedBy_#/definitions/version/properties/keywords/items');" class="control"></div>
+                                       </td>
+                                       <td>
+                                          <div id="usedBy_#/definitions/version/properties/keywords/items" style="display:block">
+                                             <table class="propertiesTable">
+                                                <tr>
+                                                   <td class="firstColumn" style="white-space: nowrap; font-family: Segoe UI; font-size: 8pt; color: #808080;">Schema</td>
+                                                   <tr class="firstColumn" style="white-space: nowrap;">
+                                                      <td><span class="Name"><a href="#/definitions/version/properties/keywords">version/properties/keywords</a></span></td>
+                                                   </tr>
+                                                </tr>
+                                             </table>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                    
+                                    <tr>
+                                       <td class="firstColumn">
+                                          <div class="floatLeft"><b>Source</b></div>
+                                          <div class="floatRight"><input id="button_source_#/definitions/version/properties/keywords/items" type="image" src="img/btM.gif" value="-" onclick="switchState('source_#/definitions/version/properties/keywords/items');" class="control"></div>
+                                       </td>
+                                       <td>
+                                          <div id="source_#/definitions/version/properties/keywords/items" style="display:block">
+                                             <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
+                                                <tr>
+                                                   <pre><span class="tEl">
+<span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,150)">"items"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"object"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"additionalProperties"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,90)">false</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"examples"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">[</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(40,40,40)">[</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(0,0,150)">"vocabulary"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"ACM"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(0,0,150)">"value"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"C.2.0;"</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(0,0,150)">"vocabulary"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"ACM"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(0,0,150)">"value"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"C.2.2"</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(40,40,40)">]</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(40,40,40)">[</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(0,0,150)">"vocabulary"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"MSC"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(0,0,150)">"value"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"46B20"</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(40,40,40)">]</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(40,40,40)">]</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"required"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">[</span><span style="color: rgb(153,51,0)">"value"</span><span style="color: rgb(40,40,40)">]</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"properties"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(0,0,150)">"vocabulary"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"Keyword vocabulary"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"The keyword vocabulary this keyword belongs to."</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"string"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"enum"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">[</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(153,51,0)">"PDG"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(153,51,0)">"PACS"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(153,51,0)">"JACOW"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(153,51,0)">"UAT"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(153,51,0)">"ACM"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(153,51,0)">"MSC"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(153,51,0)">"INIS"</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(40,40,40)">]</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(0,0,150)">"value"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"string"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"minLength"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,113,227)">1</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"Keyword"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"A keyword that is either part of a vocabulary or free-form."</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(40,40,40)">}</span><span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"></span>
+
+</span></pre>
+                                                </tr>
+                                             </table>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                    </tbody>
+                              </table>
+                           </td>
+                           <td class="rt_lineRight"></td>
+                        </tr>
+                        <tr>
+                           <td class="rt_cornerBottomLeft"></td>
+                           <td class="rt_lineBottom"></td>
+                           <td class="rt_cornerBottomRight"></td>
+                        </tr>
+                     </table><br><a name="/definitions/version/properties/keywords/items/properties/vocabulary"></a><div class="componentTitle">Definition <a href="#/definitions/version/properties/keywords/items/properties/vocabulary"><span class="Name">vocabulary</span></a><span class="qname"></span></div>
                      <table class="rt">
                         <tr>
                            <td class="rt_cornerTopLeft"></td>
@@ -10171,15 +10558,150 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                                     <tr>
                                        <td class="firstColumn">
                                           <div class="floatLeft"><b>Annotations</b></div>
-                                          <div class="floatRight"><input id="button_annotations_#/definitions/version/properties/acm_classes" type="image" src="img/btM.gif" value="-" onclick="switchState('annotations_#/definitions/version/properties/acm_classes');" class="control"></div>
+                                          <div class="floatRight"><input id="button_annotations_#/definitions/version/properties/keywords/items/properties/vocabulary" type="image" src="img/btM.gif" value="-" onclick="switchState('annotations_#/definitions/version/properties/keywords/items/properties/vocabulary');" class="control"></div>
                                        </td>
                                        <td>
-                                          <div id="annotations_#/definitions/version/properties/acm_classes" style="display:block">
+                                          <div id="annotations_#/definitions/version/properties/keywords/items/properties/vocabulary" style="display:block">
                                              <div class="annotation">
                                                 <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
                                                    <tr>
                                                       <td width="100%">
-                                                         <pre><span class="DetailName">Title  </span><span class="tT">List of ACM classes</span></pre><br><pre><span class="DetailName">Description  </span><span class="tT">Classifications from ACM Computing Classification System.</span></pre>
+                                                         <pre><span class="DetailName">Title  </span><span class="tT">Keyword vocabulary</span></pre><br><pre><span class="DetailName">Description  </span><span class="tT">The keyword vocabulary this keyword belongs to.</span></pre>
+                                                      </td>
+                                                   </tr>
+                                                </table>
+                                             </div>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                    
+                                    <tr>
+                                       <td class="firstColumn"><b>Type</b></td>
+                                       <td><b>string</b></td>
+                                    </tr>
+                                    
+                                    <tr>
+                                       <td class="firstColumn">
+                                          <div class="floatLeft"><b>Enumeration</b></div>
+                                          <div class="floatRight"><input id="button_enumeration_#/definitions/version/properties/keywords/items/properties/vocabulary" type="image" src="img/btM.gif" value="-" onclick="switchState('enumeration_#/definitions/version/properties/keywords/items/properties/vocabulary');" class="control"></div>
+                                       </td>
+                                       <td>
+                                          <div id="enumeration_#/definitions/version/properties/keywords/items/properties/vocabulary" style="display:block">
+                                             <table class="propertiesTable">
+                                                <tr>
+                                                   <td class="firstColumn" style="white-space: nowrap; font-family: Segoe UI; font-size: 8pt; color: #808080;">Values</td>
+                                                   <tr class="firstColumn" style="white-space: nowrap;">
+                                                      <td><span class="Name">PDG</span></td>
+                                                   </tr>
+                                                   <tr class="firstColumn" style="white-space: nowrap;">
+                                                      <td><span class="Name">PACS</span></td>
+                                                   </tr>
+                                                   <tr class="firstColumn" style="white-space: nowrap;">
+                                                      <td><span class="Name">JACOW</span></td>
+                                                   </tr>
+                                                   <tr class="firstColumn" style="white-space: nowrap;">
+                                                      <td><span class="Name">UAT</span></td>
+                                                   </tr>
+                                                   <tr class="firstColumn" style="white-space: nowrap;">
+                                                      <td><span class="Name">ACM</span></td>
+                                                   </tr>
+                                                   <tr class="firstColumn" style="white-space: nowrap;">
+                                                      <td><span class="Name">MSC</span></td>
+                                                   </tr>
+                                                   <tr class="firstColumn" style="white-space: nowrap;">
+                                                      <td><span class="Name">INIS</span></td>
+                                                   </tr>
+                                                </tr>
+                                             </table>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                    
+                                    <tr>
+                                       <td class="firstColumn">
+                                          <div class="floatLeft"><b>Used by</b></div>
+                                          <div class="floatRight"><input id="button_usedBy_#/definitions/version/properties/keywords/items/properties/vocabulary" type="image" src="img/btM.gif" value="-" onclick="switchState('usedBy_#/definitions/version/properties/keywords/items/properties/vocabulary');" class="control"></div>
+                                       </td>
+                                       <td>
+                                          <div id="usedBy_#/definitions/version/properties/keywords/items/properties/vocabulary" style="display:block">
+                                             <table class="propertiesTable">
+                                                <tr>
+                                                   <td class="firstColumn" style="white-space: nowrap; font-family: Segoe UI; font-size: 8pt; color: #808080;">Schema</td>
+                                                   <tr class="firstColumn" style="white-space: nowrap;">
+                                                      <td><span class="Name"><a href="#/definitions/version/properties/keywords/items">version/properties/keywords/items</a></span></td>
+                                                   </tr>
+                                                </tr>
+                                             </table>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                    
+                                    <tr>
+                                       <td class="firstColumn">
+                                          <div class="floatLeft"><b>Source</b></div>
+                                          <div class="floatRight"><input id="button_source_#/definitions/version/properties/keywords/items/properties/vocabulary" type="image" src="img/btM.gif" value="-" onclick="switchState('source_#/definitions/version/properties/keywords/items/properties/vocabulary');" class="control"></div>
+                                       </td>
+                                       <td>
+                                          <div id="source_#/definitions/version/properties/keywords/items/properties/vocabulary" style="display:block">
+                                             <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
+                                                <tr>
+                                                   <pre><span class="tEl">
+<span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,150)">"vocabulary"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"Keyword vocabulary"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"The keyword vocabulary this keyword belongs to."</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"string"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"enum"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">[</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(153,51,0)">"PDG"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(153,51,0)">"PACS"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(153,51,0)">"JACOW"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(153,51,0)">"UAT"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(153,51,0)">"ACM"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(153,51,0)">"MSC"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(153,51,0)">"INIS"</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(40,40,40)">]</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(40,40,40)">}</span><span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"></span>
+
+</span></pre>
+                                                </tr>
+                                             </table>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                    </tbody>
+                              </table>
+                           </td>
+                           <td class="rt_lineRight"></td>
+                        </tr>
+                        <tr>
+                           <td class="rt_cornerBottomLeft"></td>
+                           <td class="rt_lineBottom"></td>
+                           <td class="rt_cornerBottomRight"></td>
+                        </tr>
+                     </table><br><a name="/definitions/version/properties/keywords/items/properties/value"></a><div class="componentTitle">Definition <a href="#/definitions/version/properties/keywords/items/properties/value"><span class="Name">value</span></a><span class="qname"></span></div>
+                     <table class="rt">
+                        <tr>
+                           <td class="rt_cornerTopLeft"></td>
+                           <td class="rt_lineTop"></td>
+                           <td class="rt_cornerTopRight"></td>
+                        </tr>
+                        <tr>
+                           <td class="rt_lineLeft"></td>
+                           <td class="rt_content">
+                              <table class="component">
+                                 <tbody> 
+                                    
+                                    <tr>
+                                       <td class="firstColumn">
+                                          <div class="floatLeft"><b>Annotations</b></div>
+                                          <div class="floatRight"><input id="button_annotations_#/definitions/version/properties/keywords/items/properties/value" type="image" src="img/btM.gif" value="-" onclick="switchState('annotations_#/definitions/version/properties/keywords/items/properties/value');" class="control"></div>
+                                       </td>
+                                       <td>
+                                          <div id="annotations_#/definitions/version/properties/keywords/items/properties/value" style="display:block">
+                                             <div class="annotation">
+                                                <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
+                                                   <tr>
+                                                      <td width="100%">
+                                                         <pre><span class="DetailName">Title  </span><span class="tT">Keyword</span></pre><br><pre><span class="DetailName">Description  </span><span class="tT">A keyword that is either part of a vocabulary or free-form.</span></pre>
                                                       </td>
                                                    </tr>
                                                 </table>
@@ -10196,10 +10718,10 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                                     <tr>
                                        <td class="firstColumn">
                                           <div class="floatLeft"><b>Constraints</b></div>
-                                          <div class="floatRight"><input id="button_constraints_#/definitions/version/properties/acm_classes" type="image" src="img/btM.gif" value="-" onclick="switchState('constraints_#/definitions/version/properties/acm_classes');" class="control"></div>
+                                          <div class="floatRight"><input id="button_constraints_#/definitions/version/properties/keywords/items/properties/value" type="image" src="img/btM.gif" value="-" onclick="switchState('constraints_#/definitions/version/properties/keywords/items/properties/value');" class="control"></div>
                                        </td>
                                        <td>
-                                          <div id="constraints_#/definitions/version/properties/acm_classes" style="display:block">
+                                          <div id="constraints_#/definitions/version/properties/keywords/items/properties/value" style="display:block">
                                              <div class="annotation">
                                                 <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
                                                    <tr>
@@ -10213,22 +10735,17 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                                     </tr>
                                     
                                     <tr>
-                                       <td class="firstColumn"><b>Examples</b></td>
-                                       <td><b>C.2.0; C.2.2; C.2.3; C.2.6  I.3.5  G.1.6; F.1.1; I.2.6; G.1.3</b></td>
-                                    </tr>
-                                    
-                                    <tr>
                                        <td class="firstColumn">
                                           <div class="floatLeft"><b>Used by</b></div>
-                                          <div class="floatRight"><input id="button_usedBy_#/definitions/version/properties/acm_classes" type="image" src="img/btM.gif" value="-" onclick="switchState('usedBy_#/definitions/version/properties/acm_classes');" class="control"></div>
+                                          <div class="floatRight"><input id="button_usedBy_#/definitions/version/properties/keywords/items/properties/value" type="image" src="img/btM.gif" value="-" onclick="switchState('usedBy_#/definitions/version/properties/keywords/items/properties/value');" class="control"></div>
                                        </td>
                                        <td>
-                                          <div id="usedBy_#/definitions/version/properties/acm_classes" style="display:block">
+                                          <div id="usedBy_#/definitions/version/properties/keywords/items/properties/value" style="display:block">
                                              <table class="propertiesTable">
                                                 <tr>
                                                    <td class="firstColumn" style="white-space: nowrap; font-family: Segoe UI; font-size: 8pt; color: #808080;">Schema</td>
                                                    <tr class="firstColumn" style="white-space: nowrap;">
-                                                      <td><span class="Name"><a href="#/definitions/version">version</a></span></td>
+                                                      <td><span class="Name"><a href="#/definitions/version/properties/keywords/items">version/properties/keywords/items</a></span></td>
                                                    </tr>
                                                 </tr>
                                              </table>
@@ -10239,24 +10756,18 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                                     <tr>
                                        <td class="firstColumn">
                                           <div class="floatLeft"><b>Source</b></div>
-                                          <div class="floatRight"><input id="button_source_#/definitions/version/properties/acm_classes" type="image" src="img/btM.gif" value="-" onclick="switchState('source_#/definitions/version/properties/acm_classes');" class="control"></div>
+                                          <div class="floatRight"><input id="button_source_#/definitions/version/properties/keywords/items/properties/value" type="image" src="img/btM.gif" value="-" onclick="switchState('source_#/definitions/version/properties/keywords/items/properties/value');" class="control"></div>
                                        </td>
                                        <td>
-                                          <div id="source_#/definitions/version/properties/acm_classes" style="display:block">
+                                          <div id="source_#/definitions/version/properties/keywords/items/properties/value" style="display:block">
                                              <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
                                                 <tr>
                                                    <pre><span class="tEl">
-<span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,150)">"acm_classes"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,150)">"value"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"string"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"minLength"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,113,227)">1</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"List of ACM classes"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"Classifications from ACM Computing Classification System."</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"examples"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">[</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(153,51,0)">"C.2.0; C.2.2; C.2.3; C.2.6"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(153,51,0)">"I.3.5"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(153,51,0)">"G.1.6; F.1.1; I.2.6; G.1.3"</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(40,40,40)">]</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"$comment"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"TODO: consider array of an enumerated definition instead. Legacy input is inconsistent."</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"Keyword"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
+<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"A keyword that is either part of a vocabulary or free-form."</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(40,40,40)">}</span><span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"></span>
 
 </span></pre>
@@ -12507,8 +13018,8 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
                                                       </td>
                                                 </tr>
                                                 <tr>
-                                                   <td class="firstColumn" style="white-space: nowrap;"><a href="#/definitions/conference_info/properties/conference_titles"><span class="Name">conference_titles<br></span></a><a href="#/definitions/conference_info/properties/cnum"><span class="Name">cnum<br></span></a></td>
-                                                   <td><b>required<br>optional<br></b></td>
+                                                   <td class="firstColumn" style="white-space: nowrap;"><a href="#/definitions/conference_info/properties/conference_titles"><span class="Name">conference_titles<br></span></a></td>
+                                                   <td><b>required<br></b></td>
                                                 </tr>
                                              </table>
                                           </div>
@@ -12564,16 +13075,6 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
 <span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"minItems"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,113,227)">1</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"List of conference titles"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"items"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(0,0,150)">"cnum"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"string"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"pattern"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"^C\\d\\d-\\d\\d-\\d\\d(\\.\\d+)?$"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"CNUM identifier of the conference"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"The CNUM is based on the starting day of the conference, with an extra number appended to distinguish conferences starting on the first day."</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(0,0,150)">"examples"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">[</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(153,51,0)">"C87-12-25"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">        </span><span style="color: rgb(153,51,0)">"C87-12-25.2"</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">      </span><span style="color: rgb(40,40,40)">]</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">    </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">  </span><span style="color: rgb(40,40,40)">}</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(40,40,40)">}</span><span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"></span>
@@ -12799,124 +13300,6 @@ var usedByBoxes= new Array('usedBy_#/properties/$schema',
 <span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,150)">"items"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"string"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"minLength"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,113,227)">1</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(40,40,40)">}</span><span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"></span>
-
-</span></pre>
-                                                </tr>
-                                             </table>
-                                          </div>
-                                       </td>
-                                    </tr>
-                                    </tbody>
-                              </table>
-                           </td>
-                           <td class="rt_lineRight"></td>
-                        </tr>
-                        <tr>
-                           <td class="rt_cornerBottomLeft"></td>
-                           <td class="rt_lineBottom"></td>
-                           <td class="rt_cornerBottomRight"></td>
-                        </tr>
-                     </table><br><a name="/definitions/conference_info/properties/cnum"></a><div class="componentTitle">Definition <a href="#/definitions/conference_info/properties/cnum"><span class="Name">cnum</span></a><span class="qname"></span></div>
-                     <table class="rt">
-                        <tr>
-                           <td class="rt_cornerTopLeft"></td>
-                           <td class="rt_lineTop"></td>
-                           <td class="rt_cornerTopRight"></td>
-                        </tr>
-                        <tr>
-                           <td class="rt_lineLeft"></td>
-                           <td class="rt_content">
-                              <table class="component">
-                                 <tbody> 
-                                    
-                                    <tr>
-                                       <td class="firstColumn">
-                                          <div class="floatLeft"><b>Annotations</b></div>
-                                          <div class="floatRight"><input id="button_annotations_#/definitions/conference_info/properties/cnum" type="image" src="img/btM.gif" value="-" onclick="switchState('annotations_#/definitions/conference_info/properties/cnum');" class="control"></div>
-                                       </td>
-                                       <td>
-                                          <div id="annotations_#/definitions/conference_info/properties/cnum" style="display:block">
-                                             <div class="annotation">
-                                                <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
-                                                   <tr>
-                                                      <td width="100%">
-                                                         <pre><span class="DetailName">Title  </span><span class="tT">CNUM identifier of the conference</span></pre><br><pre><span class="DetailName">Description  </span><span class="tT">The CNUM is based on the starting day of the conference, with an extra number appended to distinguish conferences starting on the first day.</span></pre>
-                                                      </td>
-                                                   </tr>
-                                                </table>
-                                             </div>
-                                          </div>
-                                       </td>
-                                    </tr>
-                                    
-                                    <tr>
-                                       <td class="firstColumn"><b>Type</b></td>
-                                       <td><b>string</b></td>
-                                    </tr>
-                                    
-                                    <tr>
-                                       <td class="firstColumn">
-                                          <div class="floatLeft"><b>Constraints</b></div>
-                                          <div class="floatRight"><input id="button_constraints_#/definitions/conference_info/properties/cnum" type="image" src="img/btM.gif" value="-" onclick="switchState('constraints_#/definitions/conference_info/properties/cnum');" class="control"></div>
-                                       </td>
-                                       <td>
-                                          <div id="constraints_#/definitions/conference_info/properties/cnum" style="display:block">
-                                             <div class="annotation">
-                                                <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
-                                                   <tr>
-                                                      <td width="100%">
-                                                         <pre><span class="DetailName">Pattern : </span><span class="tT">^C\d\d-\d\d-\d\d(\.\d+)?$</span></pre><br></td>
-                                                   </tr>
-                                                </table>
-                                             </div>
-                                          </div>
-                                       </td>
-                                    </tr>
-                                    
-                                    <tr>
-                                       <td class="firstColumn"><b>Examples</b></td>
-                                       <td><b>C87-12-25  C87-12-25.2</b></td>
-                                    </tr>
-                                    
-                                    <tr>
-                                       <td class="firstColumn">
-                                          <div class="floatLeft"><b>Used by</b></div>
-                                          <div class="floatRight"><input id="button_usedBy_#/definitions/conference_info/properties/cnum" type="image" src="img/btM.gif" value="-" onclick="switchState('usedBy_#/definitions/conference_info/properties/cnum');" class="control"></div>
-                                       </td>
-                                       <td>
-                                          <div id="usedBy_#/definitions/conference_info/properties/cnum" style="display:block">
-                                             <table class="propertiesTable">
-                                                <tr>
-                                                   <td class="firstColumn" style="white-space: nowrap; font-family: Segoe UI; font-size: 8pt; color: #808080;">Schema</td>
-                                                   <tr class="firstColumn" style="white-space: nowrap;">
-                                                      <td><span class="Name"><a href="#/definitions/conference_info">conference_info</a></span></td>
-                                                   </tr>
-                                                </tr>
-                                             </table>
-                                          </div>
-                                       </td>
-                                    </tr>
-                                    
-                                    <tr>
-                                       <td class="firstColumn">
-                                          <div class="floatLeft"><b>Source</b></div>
-                                          <div class="floatRight"><input id="button_source_#/definitions/conference_info/properties/cnum" type="image" src="img/btM.gif" value="-" onclick="switchState('source_#/definitions/conference_info/properties/cnum');" class="control"></div>
-                                       </td>
-                                       <td>
-                                          <div id="source_#/definitions/conference_info/properties/cnum" style="display:block">
-                                             <table style="table-layout:fixed;white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space: -o-pre-wrap;word-wrap: break-word;_white-space:pre;" class="preWrapContainer">
-                                                <tr>
-                                                   <pre><span class="tEl">
-<span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(0,0,150)">"cnum"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">{</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"type"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"string"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"pattern"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"^C\\d\\d-\\d\\d-\\d\\d(\\.\\d+)?$"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"title"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"CNUM identifier of the conference"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"description"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(153,51,0)">"The CNUM is based on the starting day of the conference, with an extra number appended to distinguish conferences starting on the first day."</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(0,0,150)">"examples"</span><span style="color: rgb(100,0,50)">:</span><span style="color: rgb(0,0,0)"> </span><span style="color: rgb(40,40,40)">[</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(153,51,0)">"C87-12-25"</span><span style="color: rgb(100,0,50)">,</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">    </span><span style="color: rgb(153,51,0)">"C87-12-25.2"</span><span style="color: rgb(0,0,0)"></span>
-<span style="color: rgb(0,0,0)">  </span><span style="color: rgb(40,40,40)">]</span><span style="color: rgb(0,0,0)"></span>
 <span style="color: rgb(40,40,40)">}</span><span style="color: rgb(40,40,40)"></span><span style="color: rgb(0,0,0)"></span>
 
 </span></pre>

--- a/schema-extended/example1.json
+++ b/schema-extended/example1.json
@@ -1,11 +1,16 @@
 {
-  "identifier": "2105.01224",
-    "classifications": [
-    "hep-ex", "hep-ph"
+  "identifiers": {
+      "arxiv_id": "2105.01224"
+  },
+    "primary_classification": "hep-ex",
+    "secondary_classifications": [
+    "hep-ph"
   ],
-  "versions": [
+"versions": [
     {
-      "identifier": "2105.01224v1",
+      "identifiers": {
+          "arxiv_idv": "2105.01224v1"
+      },
       "document_types": [
         "article"
       ],
@@ -37,7 +42,10 @@
           "full_name": "Kensuke Homma",
           "first_name": "Kensuke",
           "last_name": "Homma",
-          "is_submitter": true
+          "is_submitter": true,
+          "affiliations": [
+            {"name": "Example University"}
+          ]
         },
         {
           "full_name": "Yuri Kirita",

--- a/schema-extended/example1.json
+++ b/schema-extended/example1.json
@@ -1,130 +1,122 @@
 {
   "identifiers": {
-      "arxiv_id": "2105.01224"
+    "arxiv_id": "2105.01224"
   },
-    "primary_classification": "hep-ex",
-    "secondary_classifications": [
-    "hep-ph"
-  ],
-"versions": [
-    {
-      "identifiers": {
-          "arxiv_idv": "2105.01224v1"
-      },
-      "document_types": [
-        "article"
-      ],
-      "submitted_date": "2021-05-04T12:34:56Z",
-      "announced_date": "2021-05-06T12:00:00Z",
-      "license": "http://creativecommons.org/licenses/by/4.0/",
-      "titles": [
-        {
-          "title": "Search for sub-eV axion-like resonance states via stimulated quasi-parallel laser collisions with the parameterization including fully asymmetric collisional geometry",
-          "language": "en"
-        }
-      ],
-      "abstracts": [
-        {
-          "abstract": "We have searched for axion-like resonance states by colliding optical photons in a focused laser field (creation beam) by adding another laser field (inducing beam) for stimulation of the resonance decays, where frequency-converted signal photons can be created as a result of stimulated photon-photon scattering via exchanges of axion-like resonances. A quasi-parallel collision system (QPS) in such a focused field allows access to the sub-eV mass range of resonance particles. In past searches in QPS, for simplicity, we interpreted the scattering rate based on an analytically calculable symmetric collision geometry in both incident angles and incident energies by partially implementing the asymmetric nature to meet the actual experimental conditions. In this paper, we present new search results based on a complete parameterization including fully asymmetric collisional geometries. In particular, we combined a linearly polarized creation laser and a circularly polarized inducing laser to match the new parameterization. A 0.10 mJ / 36 fs Ti:sapphire laser pulse and a 0.20 mJ / 9 ns Nd:YAG laser pulse were spatiotemporally synchronized by sharing a common optical axis and focused into the vacuum system. Under a condition in which atomic background processes were completely negligible, no significant scattering signal was observed at the vacuum pressure of $2.6 \times 10^{-5}$ Pa, thereby providing upper bounds on the coupling-mass relation by assuming exchanges of scalar and pseudoscalar fields at a 95 % confidence level in the sub-eV mass range.",
-          "language": "en"
-        }
-      ],
-      "submitter_info": {
-        "submitter": {
-          "full_name": "Kensuke Homma",
-          "first_name": "Kensuke",
-          "last_name": "Homma"
-        }
-      },
-      "legacy_authors": "Kensuke Homma, Yuri Kirita, Masaki Hashida, Yusuke Hirahara, Shunsuke Inoue, Fumiya Ishibashi, Yoshihide Nakamiya, Liviu Neagu, Akihide Nobuhiro, Takaya Ozaki, Madalin-Mihai Rosu, Shuji Sakabe, Ovidiu Tesileanu (SAPPHIRES collaboration)",
-      "authors": [
-        {
-          "full_name": "Kensuke Homma",
-          "first_name": "Kensuke",
-          "last_name": "Homma",
-          "is_submitter": true,
-          "affiliations": [
-            {"name": "Example University"}
-          ]
-        },
-        {
-          "full_name": "Yuri Kirita",
-          "first_name": "Yuri",
-          "last_name": "Kirita"
-        },
-        {
-          "full_name": "Masaki Hashida",
-          "first_name": "Masaki",
-          "last_name": "Hashida"
-        },
-        {
-          "full_name": "Yusuke Hirahara",
-          "first_name": "Yusuke",
-          "last_name": "Hirahara"
-        },
-        {
-          "full_name": "Shunsuke Inoue",
-          "first_name": "Shunsuke",
-          "last_name": "Inoue"
-        },
-        {
-          "full_name": "Fumiya Ishibashi",
-          "first_name": "Fumiya",
-          "last_name": "Ishibashi"
-        },
-        {
-          "full_name": "Yoshihide Nakamiya",
-          "first_name": "Yoshihide",
-          "last_name": "Nakamiya"
-        },
-        {
-          "full_name": "Liviu Neagu",
-          "first_name": "Liviu",
-          "last_name": "Neagu"
-        },
-        {
-          "full_name": "Akihide Nobuhiro",
-          "first_name": "Akihide",
-          "last_name": "Nobuhiro"
-        },
-        {
-          "full_name": "Takaya Ozaki",
-          "first_name": "Takaya",
-          "last_name": "Ozaki"
-        },
-        {
-          "full_name": "Madalin-Mihai Rosu",
-          "first_name": "Madalin-Mihai",
-          "last_name": "Rosu"
-        },
-        {
-          "full_name": "Shuji Sakabe",
-          "first_name": "Shuji",
-          "last_name": "Sakabe"
-        },
-        {
-          "full_name": "Ovidiu Tesileanu",
-          "first_name": "Ovidiu",
-          "last_name": "Tesileanu"
-        }
-      ],
-      "collaborations": [
-        {
-          "name": "SAPPHIRES"
-        }
-      ],
-      "comments": {
-        "legacy_comments": "32 pages, 14 figures"
-      },
-      "arxiv_status": "posted",
-      "external_publication_status": "preprint",
-      "source_info": {
-        "source_format": "tex",
-        "size_kilobytes": 5224,
-        "checksum": [
-          {"algorithm": "MD5", "value": "805a012b9a36ff706a49fc6adce08085"}
-        ]
+  "classification": {
+    "primary": "hep-ex",
+    "secondaries": [
+      "hep-ph"
+    ]
+  },
+  "versions": [{
+    "identifier": "2105.01224v1",
+    "document_types": [
+      "article"
+    ],
+    "submitted_date": "2021-05-04T12:34:56Z",
+    "announced_date": "2021-05-06T12:00:00Z",
+    "license": "http://creativecommons.org/licenses/by/4.0/",
+    "titles": [{
+      "title": "Search for sub-eV axion-like resonance states via stimulated quasi-parallel laser collisions with the parameterization including fully asymmetric collisional geometry",
+      "language": "en"
+    }],
+    "abstracts": [{
+      "abstract": "We have searched for axion-like resonance states by colliding optical photons in a focused laser field (creation beam) by adding another laser field (inducing beam) for stimulation of the resonance decays, where frequency-converted signal photons can be created as a result of stimulated photon-photon scattering via exchanges of axion-like resonances. A quasi-parallel collision system (QPS) in such a focused field allows access to the sub-eV mass range of resonance particles. In past searches in QPS, for simplicity, we interpreted the scattering rate based on an analytically calculable symmetric collision geometry in both incident angles and incident energies by partially implementing the asymmetric nature to meet the actual experimental conditions. In this paper, we present new search results based on a complete parameterization including fully asymmetric collisional geometries. In particular, we combined a linearly polarized creation laser and a circularly polarized inducing laser to match the new parameterization. A 0.10 mJ / 36 fs Ti:sapphire laser pulse and a 0.20 mJ / 9 ns Nd:YAG laser pulse were spatiotemporally synchronized by sharing a common optical axis and focused into the vacuum system. Under a condition in which atomic background processes were completely negligible, no significant scattering signal was observed at the vacuum pressure of $2.6 \times 10^{-5}$ Pa, thereby providing upper bounds on the coupling-mass relation by assuming exchanges of scalar and pseudoscalar fields at a 95 % confidence level in the sub-eV mass range.",
+      "language": "en"
+    }],
+    "submitter_info": {
+      "submitter": {
+        "full_name": "Kensuke Homma",
+        "first_name": "Kensuke",
+        "last_name": "Homma"
       }
+    },
+    "legacy_authors": "Kensuke Homma, Yuri Kirita, Masaki Hashida, Yusuke Hirahara, Shunsuke Inoue, Fumiya Ishibashi, Yoshihide Nakamiya, Liviu Neagu, Akihide Nobuhiro, Takaya Ozaki, Madalin-Mihai Rosu, Shuji Sakabe, Ovidiu Tesileanu (SAPPHIRES collaboration)",
+    "authors": [{
+        "full_name": "Kensuke Homma",
+        "first_name": "Kensuke",
+        "last_name": "Homma",
+        "is_submitter": true,
+        "affiliations": [{
+          "name": "Example University"
+        }]
+      },
+      {
+        "full_name": "Yuri Kirita",
+        "first_name": "Yuri",
+        "last_name": "Kirita"
+      },
+      {
+        "full_name": "Masaki Hashida",
+        "first_name": "Masaki",
+        "last_name": "Hashida"
+      },
+      {
+        "full_name": "Yusuke Hirahara",
+        "first_name": "Yusuke",
+        "last_name": "Hirahara"
+      },
+      {
+        "full_name": "Shunsuke Inoue",
+        "first_name": "Shunsuke",
+        "last_name": "Inoue"
+      },
+      {
+        "full_name": "Fumiya Ishibashi",
+        "first_name": "Fumiya",
+        "last_name": "Ishibashi"
+      },
+      {
+        "full_name": "Yoshihide Nakamiya",
+        "first_name": "Yoshihide",
+        "last_name": "Nakamiya"
+      },
+      {
+        "full_name": "Liviu Neagu",
+        "first_name": "Liviu",
+        "last_name": "Neagu"
+      },
+      {
+        "full_name": "Akihide Nobuhiro",
+        "first_name": "Akihide",
+        "last_name": "Nobuhiro"
+      },
+      {
+        "full_name": "Takaya Ozaki",
+        "first_name": "Takaya",
+        "last_name": "Ozaki"
+      },
+      {
+        "full_name": "Madalin-Mihai Rosu",
+        "first_name": "Madalin-Mihai",
+        "last_name": "Rosu"
+      },
+      {
+        "full_name": "Shuji Sakabe",
+        "first_name": "Shuji",
+        "last_name": "Sakabe"
+      },
+      {
+        "full_name": "Ovidiu Tesileanu",
+        "first_name": "Ovidiu",
+        "last_name": "Tesileanu"
+      }
+    ],
+    "collaborations": [{
+      "name": "SAPPHIRES"
+    }],
+    "comments": {
+      "legacy_comments": "32 pages, 14 figures"
+    },
+    "arxiv_status": "posted",
+    "external_publication_status": "preprint",
+    "source_info": {
+      "source_format": "tex",
+      "size_kilobytes": 5224,
+      "checksum": [{
+        "algorithm": "MD5",
+        "value": "805a012b9a36ff706a49fc6adce08085"
+      }]
     }
-  ]
+  }]
 }

--- a/schema-extended/example2.json
+++ b/schema-extended/example2.json
@@ -1,11 +1,13 @@
 {
-  "identifier": "1904.00012",
-  "classifications": [
-    "astro-ph.SR"
-  ],
+  "identifiers": {
+      "arxiv_id": "1904.00012"
+  },
+  "primary_classification": "astro-ph.SR",
   "versions": [
     {
-      "identifier": "1904.00012v1",
+       "identifiers": {
+          "arxiv_idv": "1904.00012v1"
+      },
       "submitted_date": "2019-03-29T18:00:00Z",
       "announced_date": "2019-04-01T01:23:45Z",
       "license": "http://arxiv.org/licenses/nonexclusive-distrib/1.0/",
@@ -86,7 +88,9 @@
       }
     },
     {
-      "identifier": "1904.00012v2",
+      "identifiers": {
+          "arxiv_idv": "1904.00012v2"
+      },
       "submitted_date": "2019-04-23T07:52:54Z",
       "announced_date": "2019-04-24T01:23:45Z",
       "license": "http://arxiv.org/licenses/nonexclusive-distrib/1.0/",
@@ -167,7 +171,9 @@
       }
     },
     {
-      "identifier": "1904.00012v3",
+      "identifiers": {
+          "arxiv_idv": "1904.00012v3"
+      },
       "submitted_date": "2019-05-21T12:34:56Z",
       "announced_date": "2019-05-22T01:23:45Z",
       "license": "http://arxiv.org/licenses/nonexclusive-distrib/1.0/",

--- a/schema-extended/example2.json
+++ b/schema-extended/example2.json
@@ -2,7 +2,9 @@
   "identifiers": {
       "arxiv_id": "1904.00012"
   },
-  "primary_classification": "astro-ph.SR",
+  "classification": {
+    "primary": "astro-ph.SR"
+  },
   "versions": [
     {
        "identifiers": {


### PR DESCRIPTION
This PR represents a third draft of an extended metadata schema for arXiv documents, and is based on the [feedback for the second draft](#32) from the members of the metadata working group as well as arXiv team members. 

The main changes are as follows:
* restores `primary_classification` and `secondary_classifications` (from `classifications`)
* consolidates `acm_classes` and `msc_classes` into `keywords`; keywords are optionally associated with a vocabulary
* consolidates arXiv-issued identifiers (arXiv ID and arXiv DOI) under `indentifiers`.
* removes `last_name` requirement for `Person` entities; only `full_name` is required.
* removes `cnum` property from `conference_info` as it is INSPIRE-specific

As with previous drafts, this draft includes all entity definitions in one place; I still intend to split them out in a subsequent clean-up.
